### PR TITLE
Provide informative logging for dups/absences

### DIFF
--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -253,11 +253,11 @@ func (qs *QuadStore) buildQuadWrite(tx *bolt.Tx, q quad.Quad, id int64, isAdd bo
 	}
 
 	if isAdd && len(entry.History)%2 == 1 {
-		glog.Error("Adding a valid quad ", entry)
+		glog.Errorf("attempt to add existing quad %v: %#v", entry, q)
 		return graph.ErrQuadExists
 	}
 	if !isAdd && len(entry.History)%2 == 0 {
-		glog.Error("Deleting an invalid quad ", entry)
+		glog.Error("attempt to delete non-existent quad %v: %#c", entry, q)
 		return graph.ErrQuadNotExist
 	}
 


### PR DESCRIPTION
We don't test for dups or absences in other backing stores AFAICS. It would be nice to harmonise the approaches used in each so that this kind of check and logging or error return can be done elsewhere.