### PR TITLE
fix broken markdown in GremlinAPI.md

### DIFF
--- a/docs/GremlinAPI.md
+++ b/docs/GremlinAPI.md
@@ -362,10 +362,10 @@ Returns: Array
 
 Executes a query and returns the results at the end of the query path.
 Example:
-``javascript
+```javascript
 // fooNames contains an Array of names for foo.
 var fooNames = g.V("foo").Out("name").ToArray()
-``
+```
 
 ####**`query.ToValue()`**
 
@@ -383,12 +383,12 @@ Returns: Array of string-to-string objects
 
 As `.ToArray` above, but instead of a list of top-level strings, returns an Array of tag-to-string dictionaries, much as `.All` would, except inside the Javascript environment.
 Example:
-``javascript
+```javascript
 // fooNames contains an Array of names for foo.
 var fooTags = g.V("foo").Tag("foo_value").Out("name").ToArray()
 // fooValue should be the string "foo"
 var fooValue = fooTags[0]["foo_value"]
-``
+```
 
 ####**`query.TagValue()`**
 


### PR DESCRIPTION
in addition to the markdown, i think there might be some copy/paste errors in the documentation regarding `TagArray`.  unfortunately, i'd only be guessing how to make it right, so maybe someone else could take a look and fix it.