### PR TITLE
Prevent empty values in cache (using mongo)

### DIFF
--- a/cayley_test.go
+++ b/cayley_test.go
@@ -392,6 +392,9 @@ func prepare(t testing.TB) {
 		}
 	case "mongo":
 		cfg.DatabasePath = "localhost:27017"
+		cfg.DatabaseOptions = map[string]interface{}{
+			"database_name": "cayley_test", // provide a default test database
+		}
 	default:
 		t.Fatalf("Untestable backend store %s", *backend)
 	}

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -300,8 +300,9 @@ func (qs *QuadStore) NameOf(v graph.Value) string {
 	err := qs.db.C("nodes").FindId(v.(string)).One(&node)
 	if err != nil {
 		glog.Errorf("Error: Couldn't retrieve node %s %v", v, err)
+	} else if node.ID != "" && node.Name != "" {
+		qs.ids.Put(v.(string), node.Name)
 	}
-	qs.ids.Put(v.(string), node.Name)
 	return node.Name
 }
 


### PR DESCRIPTION
(This is a second PR for a subset of a previous PR that failed on travis because of the mongo versions - see below).

This PR prevents empty values from nodes that are not found from being added to the cache when the mongo backend is used. I was seeing almost exactly what issue #130 was describing and decided to sit down and debug my way through it. Removing the cache logic from the NameOf function pointed me in the right direction. The logic previously was adding to the cache even if the node was not found, which was then providing the empty strings I was seeing during the queries. It will now prevent a not found node from being added to the cache.

I tested these locally against mongo version `2.6.5` and the tests passed (`go test -v -backend=mongo ./...`)! My previous PR (#179) has the commit for adding them to travis, but since travis uses `2.4.x`, the tests failed (and I verified that they failed locally with a `2.4.x` mongo as well).

I have signed the CLA, as requested.