### PR TITLE
Fix naming style issues found by lint

### DIFF
--- a/quad/cquads/parse.go
+++ b/quad/cquads/parse.go
@@ -31,7 +31,7 @@ const quadsStart int = 1
 const quadsFirstFinal int = 178
 const quadsError int = 0
 
-const quads_en_statement int = 1
+const quadsEnStatement int = 1
 
 
 // line 34 "parse.rl"

--- a/quad/cquads/parse.go
+++ b/quad/cquads/parse.go
@@ -27,9 +27,9 @@ import (
 
 
 // line 30 "parse.go"
-const quads_start int = 1
-const quads_first_final int = 178
-const quads_error int = 0
+const quadsStart int = 1
+const quadsFirstFinal int = 178
+const quadsError int = 0
 
 const quads_en_statement int = 1
 
@@ -62,7 +62,7 @@ func Parse(statement string) (quad.Quad, error) {
 	
 // line 64 "parse.go"
 	{
-	cs = quads_start
+	cs = quadsStart
 	}
 
 // line 59 "parse.rl"

--- a/quad/nquads/parse.go
+++ b/quad/nquads/parse.go
@@ -31,7 +31,7 @@ const quadsStart int = 1
 const quadsFirstFinal int = 88
 const quadsError int = 0
 
-const quads_en_statement int = 1
+const quadsEnStatement int = 1
 
 
 // line 34 "parse.rl"

--- a/quad/nquads/parse.go
+++ b/quad/nquads/parse.go
@@ -27,9 +27,9 @@ import (
 
 
 // line 30 "parse.go"
-const quads_start int = 1
-const quads_first_final int = 88
-const quads_error int = 0
+const quadsStart int = 1
+const quadsFirstFinal int = 88
+const quadsError int = 0
 
 const quads_en_statement int = 1
 
@@ -61,7 +61,7 @@ func Parse(statement string) (quad.Quad, error) {
 	
 // line 63 "parse.go"
 	{
-	cs = quads_start
+	cs = quadsStart
 	}
 
 // line 58 "parse.rl"


### PR DESCRIPTION
Few naming issues were figured out by lint. This fixes them. Also the constants "quadsFirstFinal" and "quadsError" are not used anywhere. Do we need them?