### PR TITLE
Allocate 82 bytes instead of 62 bytes in LevelDB's CreateKeyFor method

### DIFF
--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -150,7 +150,7 @@ func hashOf(s string) []byte {
 }
 
 func (qs *QuadStore) createKeyFor(d [4]quad.Direction, q quad.Quad) []byte {
-	key := make([]byte, 0, 2+(hashSize*3))
+	key := make([]byte, 0, 2+(hashSize*4))
 	// TODO(kortschak) Remove dependence on String() method.
 	key = append(key, []byte{d[0].Prefix(), d[1].Prefix()}...)
 	key = append(key, hashOf(q.Get(d[0]))...)


### PR DESCRIPTION
In LevelDB's createKeyFor method we allocate size for 3 hashes but append 4 hashes. Eventhough append handles it intelligently, the code is misleading.

CLA already signed, PR ready for review