### PR TITLE
Update GremlinAPI.md

### DIFF
--- a/docs/GremlinAPI.md
+++ b/docs/GremlinAPI.md
@@ -14,7 +14,7 @@ Arguments:
 
   * `nodeId` (Optional): A string or list of strings representing the starting vertices.
 
-Returns: Query object
+Returns: Path object
 
 Starts a query path at the given vertex/verticies. No ids means "all vertices".
 


### PR DESCRIPTION
Graph.Vertex() was documented as returning a Query object, but that didn't make sense, and then in the Path documentation it said that .Vertex() returns a Path, which does make sense.