### PR TITLE
Ensure callers get errors when they happen

### DIFF
--- a/cayley.go
+++ b/cayley.go
@@ -305,6 +305,10 @@ func decompressAndLoad(qw graph.QuadWriter, cfg *config.Config, path, typ string
 		return fmt.Errorf("unknown quad format %q", typ)
 	}
 
+	if loadFn != nil {
+		return loadFn(qw, cfg, dec)
+	}
+
 	return db.Load(qw, cfg, dec)
 }
 

--- a/cayley_test.go
+++ b/cayley_test.go
@@ -454,7 +454,10 @@ func remove(qw graph.QuadWriter, cfg *config.Config, dec quad.Unmarshaler) error
 			}
 			return err
 		}
-		qw.RemoveQuad(t)
+		err = qw.RemoveQuad(t)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -82,15 +82,21 @@ func Load(qw graph.QuadWriter, cfg *config.Config, dec quad.Unmarshaler) error {
 		block = append(block, t)
 		if len(block) == cap(block) {
 			count += len(block)
-			qw.AddQuadSet(block)
+			err := qw.AddQuadSet(block)
+			if err != nil {
+				return fmt.Errorf("db: failed to load data: %v", err)
+			}
+			block = block[:0]
 			if glog.V(2) {
 				glog.V(2).Infof("Wrote %d quads.", count)
 			}
-			block = block[:0]
 		}
 	}
 	count += len(block)
-	qw.AddQuadSet(block)
+	err := qw.AddQuadSet(block)
+	if err != nil {
+		return fmt.Errorf("db: failed to load data: %v", err)
+	}
 	if glog.V(2) {
 		glog.V(2).Infof("Wrote %d quads.", count)
 	}

--- a/writer/single.go
+++ b/writer/single.go
@@ -55,8 +55,7 @@ func (s *Single) AddQuadSet(set []quad.Quad) error {
 			Timestamp: time.Now(),
 		}
 	}
-	s.qs.ApplyDeltas(deltas)
-	return nil
+	return s.qs.ApplyDeltas(deltas)
 }
 
 func (s *Single) RemoveQuad(q quad.Quad) error {


### PR DESCRIPTION
Previously we silently dropped portions or all of a block when a duplicate quad is found. We still fail now, but we tell someone.

Fixes #201.