### PR TITLE
Make graph.Delta zero state invalid for use

### DIFF
--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"sync"
@@ -192,6 +193,9 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 		resizeMap := make(map[string]int64)
 		sizeChange := int64(0)
 		for _, d := range deltas {
+			if d.Action != graph.Add && d.Action != graph.Delete {
+				return errors.New("bolt: invalid action")
+			}
 			bytes, err := json.Marshal(d)
 			if err != nil {
 				return err

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -185,6 +185,9 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 	resizeMap := make(map[string]int64)
 	sizeChange := int64(0)
 	for _, d := range deltas {
+		if d.Action != graph.Add && d.Action != graph.Delete {
+			return errors.New("leveldb: invalid action")
+		}
 		bytes, err := json.Marshal(d)
 		if err != nil {
 			return err

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -15,6 +15,7 @@
 package memstore
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,10 +103,13 @@ func newQuadStore() *QuadStore {
 func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 	for _, d := range deltas {
 		var err error
-		if d.Action == graph.Add {
+		switch d.Action {
+		case graph.Add:
 			err = qs.AddDelta(d)
-		} else {
+		case graph.Delete:
 			err = qs.RemoveDelta(d)
+		default:
+			err = errors.New("memstore: invalid action")
 		}
 		if err != nil {
 			return err

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -17,6 +17,7 @@ package mongo
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"hash"
 	"sync"
 
@@ -218,6 +219,9 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta) error {
 	ids := make(map[string]int)
 	// Pre-check the existence condition.
 	for _, d := range in {
+		if d.Action != graph.Add && d.Action != graph.Delete {
+			return errors.New("mongo: invalid action")
+		}
 		key := qs.getIDForQuad(d.Quad)
 		switch d.Action {
 		case graph.Add:

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -28,12 +28,12 @@ import (
 	"github.com/google/cayley/quad"
 )
 
-type Procedure byte
+type Procedure int8
 
 // The different types of actions a transaction can do.
 const (
-	Add Procedure = iota
-	Delete
+	Add    Procedure = +1
+	Delete Procedure = -1
 )
 
 type Delta struct {


### PR DESCRIPTION
Previously, an incorrectly initialised Delta (omission of Action) would
result in an Add operation. Make that detectable and return an error.