### PR TITLE
Add options to ignore duplicate or missing quad

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -123,3 +123,23 @@ Optionally disable syncing to disk per transaction. Nosync being true means much
   * Default: "cayley"
 
 The name of the database within MongoDB to connect to. Manages its own collections and indicies therein.
+
+## Per-Replication Options
+
+The `replication_options` object in the main configuration file contains any of these following options that change the behavior of the replication manager.
+
+### All
+
+#### **`ignore_missing`**
+
+  * Type: Boolean
+  * Default: false
+
+Optionally ignore missing quad on delete.
+
+#### **`ignore_duplicate`**
+
+  * Type: Boolean
+  * Default: false
+
+Optionally ignore duplicated quad on add.

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -43,6 +43,7 @@ var (
 	}
 	hashSize         = sha1.Size
 	localFillPercent = 0.7
+
 )
 
 type Token struct {
@@ -208,6 +209,12 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 		for _, d := range deltas {
 			err := qs.buildQuadWrite(tx, d.Quad, d.ID.Int(), d.Action == graph.Add)
 			if err != nil {
+				if err == graph.ErrQuadExists && *graph.NoErrorDup{
+					continue
+				}
+				if err == graph.ErrQuadNotExist && *graph.NoErrorDel{
+					continue
+				}
 				return err
 			}
 			delta := int64(1)

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -185,7 +185,7 @@ var (
 	metaBucket = []byte("meta")
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	oldSize := qs.size
 	oldHorizon := qs.horizon
 	err := qs.db.Update(func(tx *bolt.Tx) error {
@@ -209,10 +209,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss boo
 		for _, d := range deltas {
 			err := qs.buildQuadWrite(tx, d.Quad, d.ID.Int(), d.Action == graph.Add)
 			if err != nil {
-				if err == graph.ErrQuadExists && ignoreDup{
+				if err == graph.ErrQuadExists && ignoreOpts.IgnoreDup{
 					continue
 				}
-				if err == graph.ErrQuadNotExist && ignoreMiss{
+				if err == graph.ErrQuadNotExist && ignoreOpts.IgnoreMissing{
 					continue
 				}
 				return err

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -185,7 +185,7 @@ var (
 	metaBucket = []byte("meta")
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
 	oldSize := qs.size
 	oldHorizon := qs.horizon
 	err := qs.db.Update(func(tx *bolt.Tx) error {
@@ -209,10 +209,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 		for _, d := range deltas {
 			err := qs.buildQuadWrite(tx, d.Quad, d.ID.Int(), d.Action == graph.Add)
 			if err != nil {
-				if err == graph.ErrQuadExists && *graph.NoErrorDup{
+				if err == graph.ErrQuadExists && ignoreDuplicate{
 					continue
 				}
-				if err == graph.ErrQuadNotExist && *graph.NoErrorDel{
+				if err == graph.ErrQuadNotExist && ignoreMissing{
 					continue
 				}
 				return err

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -185,7 +185,7 @@ var (
 	metaBucket = []byte("meta")
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss bool) error {
 	oldSize := qs.size
 	oldHorizon := qs.horizon
 	err := qs.db.Update(func(tx *bolt.Tx) error {
@@ -209,10 +209,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ign
 		for _, d := range deltas {
 			err := qs.buildQuadWrite(tx, d.Quad, d.ID.Int(), d.Action == graph.Add)
 			if err != nil {
-				if err == graph.ErrQuadExists && ignoreDuplicate{
+				if err == graph.ErrQuadExists && ignoreDup{
 					continue
 				}
-				if err == graph.ErrQuadNotExist && ignoreMissing{
+				if err == graph.ErrQuadNotExist && ignoreMiss{
 					continue
 				}
 				return err

--- a/graph/iterator/mock_ts_test.go
+++ b/graph/iterator/mock_ts_test.go
@@ -35,7 +35,7 @@ func (qs *store) ValueOf(s string) graph.Value {
 	return nil
 }
 
-func (qs *store) ApplyDeltas([]graph.Delta, bool, bool) error { return nil }
+func (qs *store) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
 
 func (qs *store) Quad(graph.Value) quad.Quad { return quad.Quad{} }
 

--- a/graph/iterator/mock_ts_test.go
+++ b/graph/iterator/mock_ts_test.go
@@ -35,7 +35,7 @@ func (qs *store) ValueOf(s string) graph.Value {
 	return nil
 }
 
-func (qs *store) ApplyDeltas([]graph.Delta) error { return nil }
+func (qs *store) ApplyDeltas([]graph.Delta, bool, bool) error { return nil }
 
 func (qs *store) Quad(graph.Value) quad.Quad { return quad.Quad{} }
 

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -181,7 +181,7 @@ var (
 	cps = [4]quad.Direction{quad.Label, quad.Predicate, quad.Subject, quad.Object}
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	batch := &leveldb.Batch{}
 	resizeMap := make(map[string]int64)
 	sizeChange := int64(0)
@@ -196,10 +196,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss boo
 		batch.Put(keyFor(d), bytes)
 		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
 		if err != nil {
-			if err == graph.ErrQuadExists && ignoreDup{
+			if err == graph.ErrQuadExists && ignoreOpts.IgnoreDup {
 				continue
 			}
-			if err == graph.ErrQuadNotExist && ignoreMiss{
+			if err == graph.ErrQuadNotExist && ignoreOpts.IgnoreMissing {
 				continue
 			}
 			return err

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -49,6 +49,7 @@ var (
 		New: func() interface{} { return sha1.New() },
 	}
 	hashSize = sha1.Size
+
 )
 
 type Token []byte
@@ -195,6 +196,12 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 		batch.Put(keyFor(d), bytes)
 		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
 		if err != nil {
+			if err == graph.ErrQuadExists && *graph.NoErrorDup{
+				continue
+			}
+			if err == graph.ErrQuadNotExist && *graph.NoErrorDel{
+				continue
+			}
 			return err
 		}
 		delta := int64(1)
@@ -243,6 +250,7 @@ func (qs *QuadStore) buildQuadWrite(batch *leveldb.Batch, q quad.Quad, id int64,
 	}
 	if err == nil {
 		// We got something.
+		fmt.Printf("Got something")
 		err = json.Unmarshal(data, &entry)
 		if err != nil {
 			return err
@@ -250,12 +258,17 @@ func (qs *QuadStore) buildQuadWrite(batch *leveldb.Batch, q quad.Quad, id int64,
 	} else {
 		entry.Quad = q
 	}
-	entry.History = append(entry.History, id)
 
-	if isAdd && len(entry.History)%2 == 0 {
-		glog.Error("Entry History is out of sync for", entry)
-		return errors.New("odd index history")
+	if isAdd && len(entry.History)%2 == 1 {
+		glog.Errorf("attempt to add existing quad %v: %#v", entry, q)
+		return graph.ErrQuadExists
 	}
+	if !isAdd && len(entry.History)%2 == 0 {
+		glog.Error("attempt to delete non-existent quad %v: %#c", entry, q)
+		return graph.ErrQuadNotExist
+	}
+
+	entry.History = append(entry.History, id)
 
 	bytes, err := json.Marshal(entry)
 	if err != nil {

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -181,7 +181,7 @@ var (
 	cps = [4]quad.Direction{quad.Label, quad.Predicate, quad.Subject, quad.Object}
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDup, ignoreMiss bool) error {
 	batch := &leveldb.Batch{}
 	resizeMap := make(map[string]int64)
 	sizeChange := int64(0)
@@ -196,10 +196,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ign
 		batch.Put(keyFor(d), bytes)
 		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
 		if err != nil {
-			if err == graph.ErrQuadExists && ignoreDuplicate{
+			if err == graph.ErrQuadExists && ignoreDup{
 				continue
 			}
-			if err == graph.ErrQuadNotExist && ignoreMissing{
+			if err == graph.ErrQuadNotExist && ignoreMiss{
 				continue
 			}
 			return err

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -250,7 +250,6 @@ func (qs *QuadStore) buildQuadWrite(batch *leveldb.Batch, q quad.Quad, id int64,
 	}
 	if err == nil {
 		// We got something.
-		fmt.Printf("Got something")
 		err = json.Unmarshal(data, &entry)
 		if err != nil {
 			return err

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -181,7 +181,7 @@ var (
 	cps = [4]quad.Direction{quad.Label, quad.Predicate, quad.Subject, quad.Object}
 )
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
 	batch := &leveldb.Batch{}
 	resizeMap := make(map[string]int64)
 	sizeChange := int64(0)
@@ -196,10 +196,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 		batch.Put(keyFor(d), bytes)
 		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
 		if err != nil {
-			if err == graph.ErrQuadExists && *graph.NoErrorDup{
+			if err == graph.ErrQuadExists && ignoreDuplicate{
 				continue
 			}
-			if err == graph.ErrQuadNotExist && *graph.NoErrorDel{
+			if err == graph.ErrQuadNotExist && ignoreMissing{
 				continue
 			}
 			return err

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -100,18 +100,18 @@ func newQuadStore() *QuadStore {
 	}
 }
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDupl, ignoreMiss bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	for _, d := range deltas {
 		var err error
 		switch d.Action {
 		case graph.Add:
 			err = qs.AddDelta(d)
-			if err != nil && ignoreDupl{
+			if err != nil && ignoreOpts.IgnoreDup{
 				err = nil
 			}
 		case graph.Delete:
 			err = qs.RemoveDelta(d)
-			if err != nil && ignoreMiss{
+			if err != nil && ignoreOpts.IgnoreMissing{
 				err = nil
 			}
 		default:

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -155,7 +155,11 @@ func (qs *QuadStore) indexOf(t quad.Quad) (int64, bool) {
 
 func (qs *QuadStore) AddDelta(d graph.Delta) error {
 	if _, exists := qs.indexOf(d.Quad); exists {
-		return graph.ErrQuadExists
+		if *graph.NoErrorDup {
+			return nil
+		}else{
+			return graph.ErrQuadExists
+		}
 	}
 	qid := qs.nextQuadID
 	qs.log = append(qs.log, LogEntry{
@@ -194,7 +198,11 @@ func (qs *QuadStore) AddDelta(d graph.Delta) error {
 func (qs *QuadStore) RemoveDelta(d graph.Delta) error {
 	prevQuadID, exists := qs.indexOf(d.Quad)
 	if !exists {
-		return graph.ErrQuadNotExist
+		if *graph.NoErrorDel {
+			return nil
+		}else{
+			return graph.ErrQuadNotExist
+		}
 	}
 
 	quadID := qs.nextQuadID

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -100,18 +100,18 @@ func newQuadStore() *QuadStore {
 	}
 }
 
-func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreDupl, ignoreMiss bool) error {
 	for _, d := range deltas {
 		var err error
 		switch d.Action {
 		case graph.Add:
 			err = qs.AddDelta(d)
-			if err != nil && ignoreDuplicate{
+			if err != nil && ignoreDupl{
 				err = nil
 			}
 		case graph.Delete:
 			err = qs.RemoveDelta(d)
-			if err != nil && ignoreMissing{
+			if err != nil && ignoreMiss{
 				err = nil
 			}
 		default:

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -214,7 +214,7 @@ func (qs *QuadStore) updateLog(d graph.Delta) error {
 	return err
 }
 
-func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
+func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDup, ignoreMiss bool) error {
 	qs.session.SetSafe(nil)
 	ids := make(map[string]int)
 	// Pre-check the existence condition.
@@ -226,7 +226,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDuplicate bool, ignoreM
 		switch d.Action {
 		case graph.Add:
 			if qs.checkValid(key) {
-				if ignoreDuplicate {
+				if ignoreDup {
 					continue
 				}else{
 					return graph.ErrQuadExists
@@ -234,7 +234,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDuplicate bool, ignoreM
 			}
 		case graph.Delete:
 			if !qs.checkValid(key) {
-				if ignoreMissing {
+				if ignoreMiss {
 					continue
 				}else{
 					return graph.ErrQuadNotExist

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -214,7 +214,7 @@ func (qs *QuadStore) updateLog(d graph.Delta) error {
 	return err
 }
 
-func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDup, ignoreMiss bool) error {
+func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	qs.session.SetSafe(nil)
 	ids := make(map[string]int)
 	// Pre-check the existence condition.
@@ -226,7 +226,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDup, ignoreMiss bool) e
 		switch d.Action {
 		case graph.Add:
 			if qs.checkValid(key) {
-				if ignoreDup {
+				if ignoreOpts.IgnoreDup {
 					continue
 				}else{
 					return graph.ErrQuadExists
@@ -234,7 +234,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDup, ignoreMiss bool) e
 			}
 		case graph.Delete:
 			if !qs.checkValid(key) {
-				if ignoreMiss {
+				if ignoreOpts.IgnoreMissing {
 					continue
 				}else{
 					return graph.ErrQuadNotExist

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -226,11 +226,19 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta) error {
 		switch d.Action {
 		case graph.Add:
 			if qs.checkValid(key) {
-				return graph.ErrQuadExists
+				if *graph.NoErrorDup {
+					continue
+				}else{
+					return graph.ErrQuadExists
+				}
 			}
 		case graph.Delete:
 			if !qs.checkValid(key) {
-				return graph.ErrQuadNotExist
+				if *graph.NoErrorDel {
+					continue
+				}else{
+					return graph.ErrQuadNotExist
+				}
 			}
 		}
 	}

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -214,7 +214,7 @@ func (qs *QuadStore) updateLog(d graph.Delta) error {
 	return err
 }
 
-func (qs *QuadStore) ApplyDeltas(in []graph.Delta) error {
+func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreDuplicate bool, ignoreMissing bool) error {
 	qs.session.SetSafe(nil)
 	ids := make(map[string]int)
 	// Pre-check the existence condition.
@@ -226,7 +226,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta) error {
 		switch d.Action {
 		case graph.Add:
 			if qs.checkValid(key) {
-				if *graph.NoErrorDup {
+				if ignoreDuplicate {
 					continue
 				}else{
 					return graph.ErrQuadExists
@@ -234,7 +234,7 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta) error {
 			}
 		case graph.Delete:
 			if !qs.checkValid(key) {
-				if *graph.NoErrorDel {
+				if ignoreMissing {
 					continue
 				}else{
 					return graph.ErrQuadNotExist

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -23,6 +23,7 @@ package graph
 
 import (
 	"errors"
+	"flag"
 
 	"github.com/barakmich/glog"
 	"github.com/google/cayley/quad"
@@ -193,3 +194,8 @@ func QuadStores() []string {
 	}
 	return t
 }
+
+var (
+	NoErrorDup = flag.Bool("noerrdup", false, "Don't stop loading on duplicated key on add")
+	NoErrorDel = flag.Bool("noerrdel", false, "Don't stop loading on missing key on delete")
+)

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -23,7 +23,6 @@ package graph
 
 import (
 	"errors"
-	"flag"
 
 	"github.com/barakmich/glog"
 	"github.com/google/cayley/quad"
@@ -45,7 +44,7 @@ type Value interface{}
 type QuadStore interface {
 	// The only way in is through building a transaction, which
 	// is done by a replication strategy.
-	ApplyDeltas([]Delta) error
+	ApplyDeltas([]Delta, bool, bool) error
 
 	// Given an opaque token, returns the quad for that token from the store.
 	Quad(Value) quad.Quad
@@ -194,8 +193,3 @@ func QuadStores() []string {
 	}
 	return t
 }
-
-var (
-	NoErrorDup = flag.Bool("noerrdup", false, "Don't stop loading on duplicated key on add")
-	NoErrorDel = flag.Bool("noerrdel", false, "Don't stop loading on missing key on delete")
-)

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -44,7 +44,7 @@ type Value interface{}
 type QuadStore interface {
 	// The only way in is through building a transaction, which
 	// is done by a replication strategy.
-	ApplyDeltas([]Delta, bool, bool) error
+	ApplyDeltas([]Delta, IgnoreOpts) error
 
 	// Given an opaque token, returns the quad for that token from the store.
 	Quad(Value) quad.Quad

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -49,6 +49,10 @@ type Handle struct {
 	QuadWriter QuadWriter
 }
 
+type IgnoreOpts struct {
+	IgnoreDup, IgnoreMissing bool
+}
+
 func (h *Handle) Close() {
 	h.QuadStore.Close()
 	h.QuadWriter.Close()

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -24,6 +24,7 @@ package graph
 import (
 	"errors"
 	"time"
+	"flag"
 
 	"github.com/google/cayley/quad"
 )
@@ -56,6 +57,11 @@ func (h *Handle) Close() {
 var (
 	ErrQuadExists   = errors.New("quad exists")
 	ErrQuadNotExist = errors.New("quad does not exist")
+)
+
+var (
+	IgnoreDup = flag.Bool("ignoredup", false, "Don't stop loading on duplicated key on add")
+	IgnoreMissing = flag.Bool("ignoremissing", false, "Don't stop loading on missing key on delete")
 )
 
 type QuadWriter interface {

--- a/writer/single.go
+++ b/writer/single.go
@@ -33,13 +33,18 @@ type Single struct {
 }
 
 func NewSingleReplication(qs graph.QuadStore, opts graph.Options) (graph.QuadWriter, error) {
-	ignoreMissing, imset := opts.BoolKey("ignore_missing")
-	if !imset {
-		ignoreMissing = *graph.IgnoreMissing
+	var ignoreMissing, ignoreDuplicate bool
+
+	if *graph.IgnoreMissing{
+		ignoreMissing = true
+	}else{
+		ignoreMissing,_ = opts.BoolKey("ignore_missing")
 	}
-	ignoreDuplicate, idset := opts.BoolKey("ignore_duplicate")
-	if !idset {
-		ignoreDuplicate = *graph.IgnoreDup
+
+	if *graph.IgnoreDup{
+		ignoreDuplicate = true
+	}else{
+		ignoreDuplicate,_ = opts.BoolKey("ignore_duplicate")
 	}
 
 	return &Single{

--- a/writer/single.go
+++ b/writer/single.go
@@ -28,8 +28,7 @@ func init() {
 type Single struct {
 	currentID        graph.PrimaryKey
 	qs               graph.QuadStore
-	ignoreMissing    bool
-	ignoreDuplicate  bool
+	ignoreOpts       graph.IgnoreOpts
 }
 
 func NewSingleReplication(qs graph.QuadStore, opts graph.Options) (graph.QuadWriter, error) {
@@ -50,8 +49,10 @@ func NewSingleReplication(qs graph.QuadStore, opts graph.Options) (graph.QuadWri
 	return &Single{
 		currentID: qs.Horizon(), 
 		qs: qs, 
-		ignoreMissing: ignoreMissing, 
-		ignoreDuplicate: ignoreDuplicate,
+		ignoreOpts: graph.IgnoreOpts{
+			IgnoreDup: ignoreDuplicate, 
+			IgnoreMissing:ignoreMissing,
+		},
 	}, nil
 }
 
@@ -63,7 +64,7 @@ func (s *Single) AddQuad(q quad.Quad) error {
 		Action:    graph.Add,
 		Timestamp: time.Now(),
 	}
-	return s.qs.ApplyDeltas(deltas, s.ignoreDuplicate, s.ignoreMissing)
+	return s.qs.ApplyDeltas(deltas, s.ignoreOpts)
 }
 
 func (s *Single) AddQuadSet(set []quad.Quad) error {
@@ -77,7 +78,7 @@ func (s *Single) AddQuadSet(set []quad.Quad) error {
 		}
 	}
 	
-	return s.qs.ApplyDeltas(deltas, s.ignoreDuplicate, s.ignoreMissing)
+	return s.qs.ApplyDeltas(deltas, s.ignoreOpts)
 }
 
 func (s *Single) RemoveQuad(q quad.Quad) error {
@@ -88,7 +89,7 @@ func (s *Single) RemoveQuad(q quad.Quad) error {
 		Action:    graph.Delete,
 		Timestamp: time.Now(),
 	}
-	return s.qs.ApplyDeltas(deltas, s.ignoreDuplicate, s.ignoreMissing)
+	return s.qs.ApplyDeltas(deltas, s.ignoreOpts)
 }
 
 func (s *Single) Close() error {


### PR DESCRIPTION
Add command line option to ignore duplicated quad when loading and ignore missing quads when deleting (two different options) as discussed in issue #201

The command line options are:
* -noerrdup to ignore duplicate
* -noerrdel to ignore missing

This is my first contribution to a go project so forgive me if some choice are not in line with the go coding style

Also note that leveldb doesn't actually detect duplicated line in the same block because is loaded in the db with the same batch. I don't know the impact of such bug.