### PR TITLE
Add support for string collation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ install:
   - go get github.com/boltdb/bolt
   - go get gopkg.in/mgo.v2
   - go get gopkg.in/mgo.v2/bson
-  - go get golang.org/x/text
+  - go get golang.org/x/text/collate
+  - go get golang.org/x/text/language
 
 script: go test -v ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - go get github.com/boltdb/bolt
   - go get gopkg.in/mgo.v2
   - go get gopkg.in/mgo.v2/bson
+  - go get golang.org/x/text
 
 script: go test -v ./...
 

--- a/cayley.go
+++ b/cayley.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	"strings"
 
 	"github.com/barakmich/glog"
 
@@ -65,6 +66,8 @@ var (
 	port               = flag.String("port", "64210", "Port to listen on.")
 	readOnly           = flag.Bool("read_only", false, "Disable writing via HTTP.")
 	timeout            = flag.Duration("timeout", 30*time.Second, "Elapsed time until an individual query times out.")
+	collationType      = flag.String("collation_type", "", "Specify the collation to use")
+	collationOptions   = flag.String("collation_options", "", "Comma separated list of collation options")
 )
 
 // Filled in by `go build ldflags="-X main.Version `ver`"`.
@@ -141,6 +144,14 @@ func configFrom(file string) *config.Config {
 	}
 
 	cfg.ReadOnly = cfg.ReadOnly || *readOnly
+
+	if cfg.CollationType == "" {
+		cfg.CollationType = *collationType
+	}
+
+	if len(cfg.CollationOptions) == 0 && *collationOptions != "" {
+		cfg.CollationOptions = strings.Split(*collationOptions,",")
+	}
 
 	return cfg
 }

--- a/cayley.go
+++ b/cayley.go
@@ -187,6 +187,7 @@ func main() {
 		handle *graph.Handle
 		err    error
 	)
+	graph.InitCollator(cfg)
 	switch cmd {
 	case "version":
 		if Version != "" {

--- a/cayley.go
+++ b/cayley.go
@@ -187,7 +187,11 @@ func main() {
 		handle *graph.Handle
 		err    error
 	)
-	graph.InitCollator(cfg)
+	err =graph.InitCollator(cfg)
+	if err != nil{
+		glog.Errorln(err)
+		os.Exit(1)
+	}
 	switch cmd {
 	case "version":
 		if Version != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	ReadOnly           bool
 	Timeout            time.Duration
 	LoadSize           int
+	CollationType      string
+	CollationOptions   []string
 }
 
 type config struct {
@@ -47,6 +49,8 @@ type config struct {
 	ReadOnly           bool                   `json:"read_only"`
 	Timeout            duration               `json:"timeout"`
 	LoadSize           int                    `json:"load_size"`
+	CollationType      string                 `json:"collation_type"`
+	CollationOptions   []string               `json:"collation_options"`
 }
 
 func (c *Config) UnmarshalJSON(data []byte) error {
@@ -66,6 +70,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		ReadOnly:           t.ReadOnly,
 		Timeout:            time.Duration(t.Timeout),
 		LoadSize:           t.LoadSize,
+		CollationType:      t.CollationType,
+		CollationOptions:   t.CollationOptions,
 	}
 	return nil
 }
@@ -82,6 +88,8 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		ReadOnly:           c.ReadOnly,
 		Timeout:            duration(c.Timeout),
 		LoadSize:           c.LoadSize,
+		CollationType:      c.CollationType,
+		CollationOptions:   c.CollationOptions,
 	})
 }
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -66,6 +66,20 @@ All command line flags take precedence over the configuration file.
 
   The number of quads to buffer from a loaded file before writing a block of quads to the database. Larger numbers are good for larger loads.
 
+#### **`collation_type`**
+
+  * Type: String
+  * Default: ""
+
+  The collation to be used for string comparison by the database. The string should be a valid BCP 47 language tag. If empty no collation is used.
+
+#### **`collation_options`**
+
+  * Type: List of String
+  * Default: []
+
+  A list of option tag to be applied to the selected collation. Valid options are: "IgnoreCase", "IgnoreDiacritics", "IgnoreWidth", "Loose", "Force", "Numeric"
+
 #### **`db_options`**
 
   * Type: Object

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -143,8 +143,11 @@ func hashOf(s string) []byte {
 	h := hashPool.Get().(hash.Hash)
 	h.Reset()
 	defer hashPool.Put(h)
+	c := graph.CollatorPool.Get().(*graph.Collator)
+	c.Reset()
+	defer graph.CollatorPool.Put(c)
 	key := make([]byte, 0, hashSize)
-	h.Write([]byte(s))
+	h.Write(c.KeyCollateStr(s))
 	key = h.Sum(key)
 	return key
 }

--- a/graph/collator.go
+++ b/graph/collator.go
@@ -44,11 +44,19 @@ func (self * Collator) Reset() {
 }
 
 func (self * Collator) KeyCollateStr(str string) []byte {
-	return self.c.KeyFromString(self.buf,str)
+	if self.c == nil {
+		return []byte(str)
+	}else{
+		return self.c.KeyFromString(self.buf,str)
+	}
 }
 
 func (self * Collator) KeyCollateBytes(str []byte) []byte {
-	return self.c.Key(self.buf,str)
+	if self.c == nil {
+		return str
+	}else{
+		return self.c.Key(self.buf,str)
+	}
 }
 
 var collatorPrototype * collate.Collator
@@ -77,10 +85,11 @@ func InitCollator(cfg * config.Config) error{
 			case "Numeric":
 				collation_options = append(collation_options,collate.Numeric)
 			default:
-				return errors.New("Unknown Option")
+				return errors.New("Collator: Unknown Option")
 		}
 	}
 
 	collatorPrototype = collate.New(lang, collation_options...)
+
 	return nil
 }

--- a/graph/collator.go
+++ b/graph/collator.go
@@ -1,0 +1,86 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+// Define the generic collator used before hashing the value for the quadstore
+
+import (
+	"sync"
+	"errors"
+
+	"github.com/google/cayley/config"
+
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
+)
+
+type Collator struct{
+	c *collate.Collator
+	buf * collate.Buffer
+}
+
+var CollatorPool = sync.Pool{
+	New: func() interface{}{ return newCollator() },
+}
+
+func newCollator() *Collator{
+	return &Collator{c: collatorPrototype, buf: &collate.Buffer{}}
+}
+
+func (self * Collator) Reset() {
+	self.buf.Reset()
+}
+
+func (self * Collator) KeyCollateStr(str string) []byte {
+	return self.c.KeyFromString(self.buf,str)
+}
+
+func (self * Collator) KeyCollateBytes(str []byte) []byte {
+	return self.c.Key(self.buf,str)
+}
+
+var collatorPrototype * collate.Collator
+
+func InitCollator(cfg * config.Config) error{
+	if cfg.CollationType == ""{
+		collatorPrototype = nil
+		return nil
+	}
+	lang := language.Make(cfg.CollationType)
+
+	collation_options := make([]collate.Option,0,len(cfg.CollationOptions))
+
+	for _,copts := range(cfg.CollationOptions){
+		switch copts {
+			case "IgnoreCase":
+				collation_options = append(collation_options,collate.IgnoreCase)
+			case "IgnoreDiacritics":
+				collation_options = append(collation_options,collate.IgnoreDiacritics)
+			case "IgnoreWidth":
+				collation_options = append(collation_options,collate.IgnoreWidth)
+			case "Loose":
+				collation_options = append(collation_options,collate.Loose)
+			case "Force":
+				collation_options = append(collation_options,collate.Force)
+			case "Numeric":
+				collation_options = append(collation_options,collate.Numeric)
+			default:
+				return errors.New("Unknown Option")
+		}
+	}
+
+	collatorPrototype = collate.New(lang, collation_options...)
+	return nil
+}

--- a/graph/collator.go
+++ b/graph/collator.go
@@ -31,9 +31,7 @@ type Collator struct{
 	buf * collate.Buffer
 }
 
-var CollatorPool = sync.Pool{
-	New: func() interface{}{ return newCollator() },
-}
+var CollatorPool sync.Pool
 
 func newCollator() *Collator{
 	return &Collator{c: collatorPrototype, buf: &collate.Buffer{}}
@@ -62,6 +60,11 @@ func (self * Collator) KeyCollateBytes(str []byte) []byte {
 var collatorPrototype * collate.Collator
 
 func InitCollator(cfg * config.Config) error{
+	// Init here. Useful only for test
+	CollatorPool = sync.Pool{
+		New: func() interface{}{ return newCollator() },
+	}
+
 	if cfg.CollationType == ""{
 		collatorPrototype = nil
 		return nil

--- a/graph/collator_test.go
+++ b/graph/collator_test.go
@@ -1,0 +1,89 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/config"
+)
+
+func initCollator(ctype string, copts []string) error{
+	cfg := &config.Config{
+		CollationType: ctype,
+		CollationOptions: copts,
+	}
+	return graph.InitCollator(cfg)
+}
+
+func TestCollatorLoose(t *testing.T) {
+	ret := initCollator("en_us", []string{"Loose"})
+	if ret != nil {
+		t.Error("Not correctly initialized")
+		return
+	}
+	col1 := graph.CollatorPool.Get().(*graph.Collator)
+	col1.Reset()
+	defer graph.CollatorPool.Put(col1)
+
+	col2 := graph.CollatorPool.Get().(*graph.Collator)
+	col2.Reset()
+	defer graph.CollatorPool.Put(col2)
+
+	col3 := graph.CollatorPool.Get().(*graph.Collator)
+	col3.Reset()
+	defer graph.CollatorPool.Put(col3)
+
+	str1 := col1.KeyCollateStr("Test")
+	str2 := col2.KeyCollateStr("test")
+	str3 := col3.KeyCollateStr("Tést")
+	if string(str1) != string(str2) {
+		t.Error("Str1 and Str2 doesn't match")
+	}
+	if string(str2) != string(str3) {
+		t.Error("Str2 and Str3 doesn't match")
+	}
+}
+
+func TestCollatorStrict(t *testing.T) {
+	ret := initCollator("en_us", []string{"Force"})
+	if ret != nil {
+		t.Error("Not correctly initialized")
+		return
+	}
+
+	col1 := graph.CollatorPool.Get().(*graph.Collator)
+	col1.Reset()
+	defer graph.CollatorPool.Put(col1)
+
+	col2 := graph.CollatorPool.Get().(*graph.Collator)
+	col2.Reset()
+	defer graph.CollatorPool.Put(col2)
+
+	col3 := graph.CollatorPool.Get().(*graph.Collator)
+	col3.Reset()
+	defer graph.CollatorPool.Put(col3)
+
+	str1 := col1.KeyCollateStr("Test")
+	str2 := col2.KeyCollateStr("test")
+	str3 := col3.KeyCollateStr("Tést")
+	if string(str1) == string(str2) {
+		t.Error("Str1 and Str2 match")
+	}
+	if string(str2) == string(str3) {
+		t.Error("Str2 and Str3 match")
+	}
+}


### PR DESCRIPTION
This is just an initial pull requests to implement the support for string collation (somewhat similar to what exists in SQL Databases) that address the issue #200. It is just a starting point, I have some doubts that should be addressed.
The collation is supported only on BoltDB for now but the implementation on other storage engine should be easy.

## Basic idea
Right now the indexes to search in the database use the hash of the string. In order to support the string collation, before hashing the stream, the string is converted to its comparison key using the used collator. If no collation is specified the storage engine works as before.

## Configuration
In order to configure the collation the following options have been added to the configuration file:
#### **`collation_type`**

  * Type: String
  * Default: ""

  The collation to be used for string comparison by the database. The string should be a valid BCP 47 language tag. If empty no collation is used.

#### **`collation_options`**

  * Type: List of String
  * Default: []

  A list of option tag to be applied to the selected collation. Valid options are: "IgnoreCase", "IgnoreDiacritics", "IgnoreWidth", "Loose", "Force", "Numeric"

The same options are available on the command line with `-collation_type` and `-collation_options`. The later is a comma separated string.

## Open questions

* Right now every string is collated. A proper implementation should implement a different behavior based on the type of the object as defined by RDF standard (http://www.w3.org/TR/n-quads/#n-quads-language):
  * IRI should not be collated
  * string literals should be collated according to the specified language or the default if it is not defined.
  * string that represents a different datatype should not be collated

  I'm not happy with this level of complication because it would complicate the query. A differentiation between IRIs (that should NOT be collated) and string (to be collated) could be interesting even if I think that right now the parser drops the the angular bracket so more work is required.
* If the db is opened with a different collation there's no error but the behavior could be unexpected. Probably the collation should be stored in the db and checked open start.
* The Collator is now implemented in the graph package but should be probably moved in a different package.
* Only one collation is supported right now. Multiple collation support (e.g: specifying it at connection level) could be used but it should be properly designed and I don't see a use case.