### PR TITLE
Add Err() and Close() methods to Iterators

### DIFF
--- a/graph/bolt/all_iterator.go
+++ b/graph/bolt/all_iterator.go
@@ -174,10 +174,11 @@ func (it *AllIterator) Contains(v graph.Value) bool {
 	return true
 }
 
-func (it *AllIterator) Close() {
+func (it *AllIterator) Close() error {
 	it.result = nil
 	it.buffer = nil
 	it.done = true
+	return nil
 }
 
 func (it *AllIterator) Size() (int64, bool) {

--- a/graph/bolt/all_iterator.go
+++ b/graph/bolt/all_iterator.go
@@ -204,3 +204,5 @@ func (it *AllIterator) Stats() graph.IteratorStats {
 		Size:         s,
 	}
 }
+
+var _ graph.Nexter = &AllIterator{}

--- a/graph/bolt/all_iterator.go
+++ b/graph/bolt/all_iterator.go
@@ -33,6 +33,7 @@ type AllIterator struct {
 	dir    quad.Direction
 	qs     *QuadStore
 	result *Token
+	err    error
 	buffer [][]byte
 	offset int
 	done   bool
@@ -121,6 +122,7 @@ func (it *AllIterator) Next() bool {
 		})
 		if err != nil {
 			glog.Error("Error nexting in database: ", err)
+			it.err = err
 			it.done = true
 			return false
 		}
@@ -132,6 +134,10 @@ func (it *AllIterator) Next() bool {
 		return false
 	}
 	return true
+}
+
+func (it *AllIterator) Err() error {
+	return it.err
 }
 
 func (it *AllIterator) ResultTree() *graph.ResultTree {

--- a/graph/bolt/iterator.go
+++ b/graph/bolt/iterator.go
@@ -106,10 +106,11 @@ func (it *Iterator) Clone() graph.Iterator {
 	return out
 }
 
-func (it *Iterator) Close() {
+func (it *Iterator) Close() error {
 	it.result = nil
 	it.buffer = nil
 	it.done = true
+	return nil
 }
 
 func (it *Iterator) isLiveValue(val []byte) bool {

--- a/graph/bolt/iterator.go
+++ b/graph/bolt/iterator.go
@@ -46,6 +46,7 @@ type Iterator struct {
 	dir     quad.Direction
 	qs      *QuadStore
 	result  *Token
+	err     error
 	buffer  [][]byte
 	offset  int
 	done    bool
@@ -170,6 +171,7 @@ func (it *Iterator) Next() bool {
 		if err != nil {
 			if err != errNotExist {
 				glog.Errorf("Error nexting in database: %v", err)
+				it.err = err
 			}
 			it.done = true
 			return false
@@ -182,6 +184,10 @@ func (it *Iterator) Next() bool {
 		return false
 	}
 	return true
+}
+
+func (it *Iterator) Err() error {
+	return it.err
 }
 
 func (it *Iterator) ResultTree() *graph.ResultTree {

--- a/graph/bolt/iterator.go
+++ b/graph/bolt/iterator.go
@@ -316,3 +316,5 @@ func (it *Iterator) Stats() graph.IteratorStats {
 		Size:         s,
 	}
 }
+
+var _ graph.Nexter = &Iterator{}

--- a/graph/bolt/iterator.go
+++ b/graph/bolt/iterator.go
@@ -46,11 +46,11 @@ type Iterator struct {
 	dir     quad.Direction
 	qs      *QuadStore
 	result  *Token
-	err     error
 	buffer  [][]byte
 	offset  int
 	done    bool
 	size    int64
+	err     error
 }
 
 func NewIterator(bucket []byte, d quad.Direction, value graph.Value, qs *QuadStore) *Iterator {

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -92,7 +92,10 @@ func newQuadStore(path string, options graph.Options) (graph.QuadStore, error) {
 	}
 	qs.db = db
 	// BoolKey returns false on non-existence. IE, Sync by default.
-	qs.db.NoSync, _ = options.BoolKey("nosync")
+	qs.db.NoSync, _, err = options.BoolKey("nosync")
+	if err != nil {
+		return nil, err
+	}
 	err = qs.getMetadata()
 	if err != nil {
 		return nil, err

--- a/graph/gaedatastore/iterator.go
+++ b/graph/gaedatastore/iterator.go
@@ -41,6 +41,7 @@ type Iterator struct {
 	offset int
 	last   string
 	result graph.Value
+	err    error
 }
 
 var (
@@ -267,7 +268,8 @@ func (it *Iterator) Next() bool {
 		}
 		if err != nil {
 			glog.Errorf("Error fetching next entry %v", err)
-			break
+			it.err = err
+			return false
 		}
 		if !skip {
 			it.buffer = append(it.buffer, k.StringID())
@@ -286,6 +288,10 @@ func (it *Iterator) Next() bool {
 	// First result
 	it.result = &Token{Kind: it.kind, Hash: it.buffer[it.offset]}
 	return true
+}
+
+func (it *Iterator) Err() error {
+	return it.err
 }
 
 func (it *Iterator) Size() (int64, bool) {

--- a/graph/gaedatastore/iterator.go
+++ b/graph/gaedatastore/iterator.go
@@ -323,3 +323,5 @@ func (it *Iterator) Stats() graph.IteratorStats {
 		Size:         size,
 	}
 }
+
+var _ graph.Nexter = &Iterator{}

--- a/graph/gaedatastore/iterator.go
+++ b/graph/gaedatastore/iterator.go
@@ -130,12 +130,13 @@ func (it *Iterator) Reset() {
 	it.result = nil
 }
 
-func (it *Iterator) Close() {
+func (it *Iterator) Close() error {
 	it.buffer = nil
 	it.offset = 0
 	it.done = true
 	it.last = ""
 	it.result = nil
+	return nil
 }
 
 func (it *Iterator) Tagger() *graph.Tagger {

--- a/graph/gaedatastore/quadstore.go
+++ b/graph/gaedatastore/quadstore.go
@@ -154,7 +154,7 @@ func getContext(opts graph.Options) (appengine.Context, error) {
 	req := opts["HTTPRequest"].(*http.Request)
 	if req == nil {
 		err := errors.New("HTTP Request needed")
-		glog.Fatalln(err)
+		glog.Errorln(err)
 		return nil, err
 	}
 	return appengine.NewContext(req), nil

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -136,7 +136,7 @@ type Iterator interface {
 	Describe() Description
 
 	// Close the iterator and do internal cleanup.
-	Close()
+	Close() error
 
 	// UID returns the unique identifier of the iterator.
 	UID() uint64

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -100,7 +100,7 @@ type Iterator interface {
 	// Contains returns whether the value is within the set held by the iterator.
 	Contains(Value) bool
 
-	// Err returns the error (if any) encountered during iteration.
+	// Err returns any error that was encountered by the Iterator.
 	Err() error
 
 	// Start iteration from the beginning

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -177,6 +177,17 @@ func Next(it Iterator) bool {
 	return false
 }
 
+// Err is a convenience function that conditionally calls the Err method
+// of an Iterator if it is a Nexter.  If the Iterator is not a Nexter, Err
+// returns nil.
+func Err(it Iterator) error {
+	if n, ok := it.(Nexter); ok {
+		return n.Err()
+	}
+	glog.Errorln("Calling Err on an un-nextable iterator")
+	return nil
+}
+
 // Height is a convienence function to measure the height of an iterator tree.
 func Height(it Iterator, until Type) int {
 	if it.Type() == until {

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -155,8 +155,13 @@ type Description struct {
 
 type Nexter interface {
 	// Next advances the iterator to the next value, which will then be available through
-	// the Result method. It returns false if no further advancement is possible.
+	// the Result method. It returns false if no further advancement is possible, or if an
+	// error was encountered during iteration.  Err should be consulted to distinguish
+	// between the two cases.
 	Next() bool
+
+	// Err returns the error (if any) encountered during iteration.
+	Err() error
 
 	Iterator
 }

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -177,17 +177,6 @@ func Next(it Iterator) bool {
 	return false
 }
 
-// Err is a convenience function that conditionally calls the Err method
-// of an Iterator if it is a Nexter.  If the Iterator is not a Nexter, Err
-// returns nil.
-func Err(it Iterator) error {
-	if n, ok := it.(Nexter); ok {
-		return n.Err()
-	}
-	glog.Errorln("Calling Err on an un-nextable iterator")
-	return nil
-}
-
 // Height is a convienence function to measure the height of an iterator tree.
 func Height(it Iterator, until Type) int {
 	if it.Type() == until {

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -100,6 +100,9 @@ type Iterator interface {
 	// Contains returns whether the value is within the set held by the iterator.
 	Contains(Value) bool
 
+	// Err returns the error (if any) encountered during iteration.
+	Err() error
+
 	// Start iteration from the beginning
 	Reset()
 
@@ -159,9 +162,6 @@ type Nexter interface {
 	// error was encountered during iteration.  Err should be consulted to distinguish
 	// between the two cases.
 	Next() bool
-
-	// Err returns the error (if any) encountered during iteration.
-	Err() error
 
 	Iterator
 }

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -103,6 +103,11 @@ func (it *Int64) Next() bool {
 	return graph.NextLogOut(it, val, true)
 }
 
+func (it *Int64) Err() error {
+	// This iterator should never error.
+	return nil
+}
+
 // DEPRECATED
 func (it *Int64) ResultTree() *graph.ResultTree {
 	return graph.NewResultTree(it.Result())

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -55,7 +55,9 @@ func (it *Int64) Reset() {
 	it.at = it.min
 }
 
-func (it *Int64) Close() {}
+func (it *Int64) Close() error {
+	return nil
+}
 
 func (it *Int64) Clone() graph.Iterator {
 	out := NewInt64(it.min, it.max)

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -160,3 +160,5 @@ func (it *Int64) Stats() graph.IteratorStats {
 		Contains:     it.runstats.Contains,
 	}
 }
+
+var _ graph.Nexter = &Int64{}

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -106,7 +106,6 @@ func (it *Int64) Next() bool {
 }
 
 func (it *Int64) Err() error {
-	// This iterator should never error.
 	return nil
 }
 

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -293,9 +293,9 @@ func (it *And) Close() error {
 
 	err := it.primaryIt.Close()
 	for _, sub := range it.internalIterators {
-		serr := sub.Close()
-		if serr != nil && err == nil {
-			err = serr
+		_err := sub.Close()
+		if _err != nil && err == nil {
+			err = _err
 		}
 	}
 

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -29,6 +29,7 @@ type And struct {
 	primaryIt         graph.Iterator
 	checkList         []graph.Iterator
 	result            graph.Value
+	err               error
 	runstats          graph.IteratorStats
 }
 
@@ -153,7 +154,14 @@ func (it *And) Next() bool {
 			return graph.NextLogOut(it, curr, true)
 		}
 	}
+	if err := graph.Err(it.primaryIt); err != nil {
+		it.err = err
+	}
 	return graph.NextLogOut(it, nil, false)
+}
+
+func (it *And) Err() error {
+	return it.err
 }
 
 func (it *And) Result() graph.Value {

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -265,3 +265,5 @@ func (it *And) Close() {
 
 // Register this as an "and" iterator.
 func (it *And) Type() graph.Type { return graph.And }
+
+var _ graph.Nexter = &And{}

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -154,7 +154,7 @@ func (it *And) Next() bool {
 			return graph.NextLogOut(it, curr, true)
 		}
 	}
-	if err := graph.Err(it.primaryIt); err != nil {
+	if err := it.primaryIt.Err(); err != nil {
 		it.err = err
 	}
 	return graph.NextLogOut(it, nil, false)

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -190,8 +190,13 @@ func (it *And) checkContainsList(val graph.Value, lastResult graph.Value) bool {
 	for i, c := range it.checkList {
 		ok = c.Contains(val)
 		if !ok {
+			if err := c.Err(); err != nil {
+				it.err = err
+				return false
+			}
 			if lastResult != nil {
 				for j := 0; j < i; j++ {
+					// TODO(andrew-d): Should this result actually be used?
 					it.checkList[j].Contains(lastResult)
 				}
 			}
@@ -249,9 +254,17 @@ func (it *And) NextPath() bool {
 	if it.primaryIt.NextPath() {
 		return true
 	}
+	if err := it.primaryIt.Err(); err != nil {
+		it.err = err
+		return false
+	}
 	for _, sub := range it.internalIterators {
 		if sub.NextPath() {
 			return true
+		}
+		if err := sub.Err(); err != nil {
+			it.err = err
+			return false
 		}
 	}
 	return false

--- a/graph/iterator/and_iterator_test.go
+++ b/graph/iterator/and_iterator_test.go
@@ -142,8 +142,8 @@ func TestAllIterators(t *testing.T) {
 }
 
 func TestAndIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	allErr := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	allErr := newTestIterator(false, wantErr)
 
 	and := NewAnd()
 	and.AddSubIterator(allErr)
@@ -152,7 +152,7 @@ func TestAndIteratorErr(t *testing.T) {
 	if and.Next() != false {
 		t.Errorf("And iterator did not pass through initial 'false'")
 	}
-	if and.Err() != retErr {
+	if and.Err() != wantErr {
 		t.Errorf("And iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/and_iterator_test.go
+++ b/graph/iterator/and_iterator_test.go
@@ -15,6 +15,7 @@
 package iterator
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/cayley/graph"
@@ -138,5 +139,20 @@ func TestAllIterators(t *testing.T) {
 	if and.Next() {
 		t.Error("Too many values")
 	}
+}
 
+func TestAndIteratorErr(t *testing.T) {
+	retErr := errors.New("unique")
+	allErr := newTestIterator(false, retErr)
+
+	and := NewAnd()
+	and.AddSubIterator(allErr)
+	and.AddSubIterator(NewInt64(1, 5))
+
+	if and.Next() != false {
+		t.Errorf("And iterator did not pass through initial 'false'")
+	}
+	if and.Err() != retErr {
+		t.Errorf("And iterator did not pass through underlying Err")
+	}
 }

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -186,3 +186,5 @@ func (it *Fixed) Stats() graph.IteratorStats {
 		Size:         int64(len(it.values)),
 	}
 }
+
+var _ graph.Nexter = &Fixed{}

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -63,7 +63,9 @@ func (it *Fixed) Reset() {
 	it.lastIndex = 0
 }
 
-func (it *Fixed) Close() {}
+func (it *Fixed) Close() error {
+	return nil
+}
 
 func (it *Fixed) Tagger() *graph.Tagger {
 	return &it.tags

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -146,7 +146,6 @@ func (it *Fixed) Next() bool {
 }
 
 func (it *Fixed) Err() error {
-	// This iterator should never error.
 	return nil
 }
 

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -143,6 +143,11 @@ func (it *Fixed) Next() bool {
 	return graph.NextLogOut(it, out, true)
 }
 
+func (it *Fixed) Err() error {
+	// This iterator should never error.
+	return nil
+}
+
 // DEPRECATED
 func (it *Fixed) ResultTree() *graph.ResultTree {
 	return graph.NewResultTree(it.Result())

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -247,11 +247,17 @@ func (it *HasA) Stats() graph.IteratorStats {
 }
 
 // Close the subiterator, the result iterator (if any) and the HasA.
-func (it *HasA) Close() {
+func (it *HasA) Close() error {
+	var ret error
+
 	if it.resultIt != nil {
-		it.resultIt.Close()
+		ret = it.resultIt.Close()
 	}
-	it.primaryIt.Close()
+	if err := it.primaryIt.Close(); err != nil && ret != nil {
+		ret = err
+	}
+
+	return ret
 }
 
 // Register this iterator as a HasA.

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -153,7 +153,11 @@ func (it *HasA) Contains(val graph.Value) bool {
 		it.resultIt.Close()
 	}
 	it.resultIt = it.qs.QuadIterator(it.dir, val)
-	return graph.ContainsLogOut(it, val, it.NextContains())
+	ret := it.NextContains()
+	if it.err != nil {
+		return false
+	}
+	return graph.ContainsLogOut(it, val, ret)
 }
 
 // NextContains() is shared code between Contains() and GetNextResult() -- calls next on the
@@ -170,6 +174,9 @@ func (it *HasA) NextContains() bool {
 			it.result = it.qs.QuadDirection(link, it.dir)
 			return true
 		}
+	}
+	if err := it.resultIt.Err(); err != nil {
+		it.err = err
 	}
 	return false
 }
@@ -188,6 +195,9 @@ func (it *HasA) NextPath() bool {
 	}
 	result := it.NextContains()
 	glog.V(4).Infoln("HASA", it.UID(), "NextPath Returns", result, "")
+	if it.err != nil {
+		return false
+	}
 	return result
 }
 

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -252,3 +252,5 @@ func (it *HasA) Type() graph.Type { return graph.HasA }
 func (it *HasA) Size() (int64, bool) {
 	return it.Stats().Size, false
 }
+
+var _ graph.Nexter = &HasA{}

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -51,6 +51,7 @@ type HasA struct {
 	dir       quad.Direction
 	resultIt  graph.Iterator
 	result    graph.Value
+	err       error
 	runstats  graph.IteratorStats
 }
 
@@ -202,12 +203,19 @@ func (it *HasA) Next() bool {
 	it.resultIt = &Null{}
 
 	if !graph.Next(it.primaryIt) {
+		if err := graph.Err(it.primaryIt); err != nil {
+			it.err = err
+		}
 		return graph.NextLogOut(it, 0, false)
 	}
 	tID := it.primaryIt.Result()
 	val := it.qs.QuadDirection(tID, it.dir)
 	it.result = val
 	return graph.NextLogOut(it, val, true)
+}
+
+func (it *HasA) Err() error {
+	return it.err
 }
 
 func (it *HasA) Result() graph.Value {

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -203,7 +203,7 @@ func (it *HasA) Next() bool {
 	it.resultIt = &Null{}
 
 	if !graph.Next(it.primaryIt) {
-		if err := graph.Err(it.primaryIt); err != nil {
+		if err := it.primaryIt.Err(); err != nil {
 			it.err = err
 		}
 		return graph.NextLogOut(it, 0, false)

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -193,11 +193,16 @@ func (it *HasA) NextPath() bool {
 	if it.primaryIt.NextPath() {
 		return true
 	}
-	result := it.NextContains()
-	glog.V(4).Infoln("HASA", it.UID(), "NextPath Returns", result, "")
+	if err := it.primaryIt.Err(); err != nil {
+		it.err = err
+		return false
+	}
+
+	result := it.NextContains() // Sets it.err if there's an error
 	if it.err != nil {
 		return false
 	}
+	glog.V(4).Infoln("HASA", it.UID(), "NextPath Returns", result, "")
 	return result
 }
 

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -263,9 +263,9 @@ func (it *HasA) Close() error {
 	err := it.primaryIt.Close()
 
 	if it.resultIt != nil {
-		err2 := it.resultIt.Close()
+		_err := it.resultIt.Close()
 		if err == nil {
-			err = err2
+			err = _err
 		}
 	}
 

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -247,6 +247,9 @@ func (it *HasA) Stats() graph.IteratorStats {
 }
 
 // Close the subiterator, the result iterator (if any) and the HasA.
+//
+// Note: as this involves closing multiple iterators, only the first error
+// encountered while closing will be reported (if any).
 func (it *HasA) Close() error {
 	var ret error
 

--- a/graph/iterator/hasa_iterator_test.go
+++ b/graph/iterator/hasa_iterator_test.go
@@ -1,0 +1,37 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/cayley/quad"
+)
+
+func TestHasAIteratorErr(t *testing.T) {
+	retErr := errors.New("unique")
+	errIt := newTestIterator(false, retErr)
+
+	// TODO(andrew-d): pass a non-nil quadstore
+	hasa := NewHasA(nil, errIt, quad.Subject)
+
+	if hasa.Next() != false {
+		t.Errorf("HasA iterator did not pass through initial 'false'")
+	}
+	if hasa.Err() != retErr {
+		t.Errorf("HasA iterator did not pass through underlying Err")
+	}
+}

--- a/graph/iterator/hasa_iterator_test.go
+++ b/graph/iterator/hasa_iterator_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func TestHasAIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	errIt := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	errIt := newTestIterator(false, wantErr)
 
 	// TODO(andrew-d): pass a non-nil quadstore
 	hasa := NewHasA(nil, errIt, quad.Subject)
@@ -31,7 +31,7 @@ func TestHasAIteratorErr(t *testing.T) {
 	if hasa.Next() != false {
 		t.Errorf("HasA iterator did not pass through initial 'false'")
 	}
-	if hasa.Err() != retErr {
+	if hasa.Err() != wantErr {
 		t.Errorf("HasA iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/iterator.go
+++ b/graph/iterator/iterator.go
@@ -116,3 +116,5 @@ func (it *Null) Close() {}
 func (it *Null) Stats() graph.IteratorStats {
 	return graph.IteratorStats{}
 }
+
+var _ graph.Nexter = &Null{}

--- a/graph/iterator/iterator.go
+++ b/graph/iterator/iterator.go
@@ -114,7 +114,9 @@ func (it *Null) Size() (int64, bool) {
 
 func (it *Null) Reset() {}
 
-func (it *Null) Close() {}
+func (it *Null) Close() error {
+	return nil
+}
 
 // A null iterator costs nothing. Use it!
 func (it *Null) Stats() graph.IteratorStats {

--- a/graph/iterator/iterator.go
+++ b/graph/iterator/iterator.go
@@ -88,6 +88,10 @@ func (it *Null) Next() bool {
 	return false
 }
 
+func (it *Null) Err() error {
+	return nil
+}
+
 func (it *Null) Result() graph.Value {
 	return nil
 }

--- a/graph/iterator/iterator_test.go
+++ b/graph/iterator/iterator_test.go
@@ -1,0 +1,29 @@
+package iterator
+
+import (
+	"github.com/google/cayley/graph"
+)
+
+// A testing iterator that returns the given values for Next() and Err().
+type testIterator struct {
+	*Fixed
+
+	NextVal bool
+	ErrVal  error
+}
+
+func newTestIterator(next bool, err error) graph.Iterator {
+	return &testIterator{
+		Fixed:   NewFixed(Identity),
+		NextVal: next,
+		ErrVal:  err,
+	}
+}
+
+func (it *testIterator) Next() bool {
+	return it.NextVal
+}
+
+func (it *testIterator) Err() error {
+	return it.ErrVal
+}

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -181,9 +181,17 @@ func (it *LinksTo) Result() graph.Value {
 }
 
 // Close our subiterators.
-func (it *LinksTo) Close() {
-	it.nextIt.Close()
-	it.primaryIt.Close()
+func (it *LinksTo) Close() error {
+	var ret error
+
+	if err := it.nextIt.Close(); err != nil && ret != nil {
+		ret = err
+	}
+	if err := it.primaryIt.Close(); err != nil && ret != nil {
+		ret = err
+	}
+
+	return ret
 }
 
 // We won't ever have a new result, but our subiterators might.

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -214,3 +214,5 @@ func (it *LinksTo) Stats() graph.IteratorStats {
 func (it *LinksTo) Size() (int64, bool) {
 	return it.Stats().Size, false
 }
+
+var _ graph.Nexter = &LinksTo{}

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -195,7 +195,7 @@ func (it *LinksTo) Result() graph.Value {
 	return it.result
 }
 
-// Close our subiterators.  It closes all subiterators it can, but
+// Close closes the iterator.  It closes all subiterators it can, but
 // returns the first error it encounters.
 func (it *LinksTo) Close() error {
 	err := it.nextIt.Close()

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -126,6 +126,9 @@ func (it *LinksTo) Contains(val graph.Value) bool {
 		it.result = val
 		return graph.ContainsLogOut(it, val, true)
 	}
+	if err := it.primaryIt.Err(); err != nil {
+		it.err = err
+	}
 	return graph.ContainsLogOut(it, val, false)
 }
 
@@ -213,7 +216,11 @@ func (it *LinksTo) Close() error {
 
 // We won't ever have a new result, but our subiterators might.
 func (it *LinksTo) NextPath() bool {
-	return it.primaryIt.NextPath()
+	ret := it.primaryIt.NextPath()
+	if !ret {
+		it.err = it.primaryIt.Err()
+	}
+	return ret
 }
 
 // Register the LinksTo.

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -181,6 +181,9 @@ func (it *LinksTo) Result() graph.Value {
 }
 
 // Close our subiterators.
+//
+// Note: as this involves closing multiple subiterators, only the first error
+// encountered while closing will be reported (if any).
 func (it *LinksTo) Close() error {
 	var ret error
 

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -166,7 +166,7 @@ func (it *LinksTo) Next() bool {
 	}
 
 	// If there's an error in the 'next' iterator, we save it and we're done.
-	if err := graph.Err(it.nextIt); err != nil {
+	if err := it.nextIt.Err(); err != nil {
 		it.err = err
 		return false
 	}

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -200,9 +200,9 @@ func (it *LinksTo) Result() graph.Value {
 func (it *LinksTo) Close() error {
 	err := it.nextIt.Close()
 
-	err2 := it.primaryIt.Close()
-	if err2 != nil && err == nil {
-		err = err2
+	_err := it.primaryIt.Close()
+	if _err != nil && err == nil {
+		err = _err
 	}
 
 	return err

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -69,11 +69,11 @@ func (it *Materialize) Reset() {
 	it.index = -1
 }
 
-func (it *Materialize) Close() {
-	it.subIt.Close()
+func (it *Materialize) Close() error {
 	it.containsMap = nil
 	it.values = nil
 	it.hasRun = false
+	return it.subIt.Close()
 }
 
 func (it *Materialize) Tagger() *graph.Tagger {

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -206,7 +206,7 @@ func (it *Materialize) Next() bool {
 	}
 	if it.aborted {
 		n := graph.Next(it.subIt)
-		if err := graph.Err(it.subIt); err != nil {
+		if err := it.subIt.Err(); err != nil {
 			it.err = err
 		}
 		return n
@@ -296,7 +296,7 @@ func (it *Materialize) materializeSet() {
 			it.actualSize += 1
 		}
 	}
-	if err := graph.Err(it.subIt); err != nil {
+	if err := it.subIt.Err(); err != nil {
 		it.err = err
 	} else if it.aborted {
 		if glog.V(2) {

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -230,6 +230,9 @@ func (it *Materialize) Contains(v graph.Value) bool {
 	if !it.hasRun {
 		it.materializeSet()
 	}
+	if it.err != nil {
+		return false
+	}
 	if it.aborted {
 		return it.subIt.Contains(v)
 	}
@@ -248,6 +251,9 @@ func (it *Materialize) Contains(v graph.Value) bool {
 func (it *Materialize) NextPath() bool {
 	if !it.hasRun {
 		it.materializeSet()
+	}
+	if it.err != nil {
+		return false
 	}
 	if it.aborted {
 		return it.subIt.NextPath()

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -48,8 +48,8 @@ type Materialize struct {
 	subIt       graph.Iterator
 	hasRun      bool
 	aborted     bool
-	err         error
 	runstats    graph.IteratorStats
+	err         error
 }
 
 func NewMaterialize(sub graph.Iterator) *Materialize {
@@ -206,9 +206,7 @@ func (it *Materialize) Next() bool {
 	}
 	if it.aborted {
 		n := graph.Next(it.subIt)
-		if err := it.subIt.Err(); err != nil {
-			it.err = err
-		}
+		it.err = it.subIt.Err()
 		return n
 	}
 
@@ -302,9 +300,8 @@ func (it *Materialize) materializeSet() {
 			it.actualSize += 1
 		}
 	}
-	if err := it.subIt.Err(); err != nil {
-		it.err = err
-	} else if it.aborted {
+	it.err = it.subIt.Err()
+	if it.err == nil && it.aborted {
 		if glog.V(2) {
 			glog.V(2).Infoln("Aborting subiterator")
 		}

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -293,3 +293,5 @@ func (it *Materialize) materializeSet() {
 	}
 	it.hasRun = true
 }
+
+var _ graph.Nexter = &Materialize{}

--- a/graph/iterator/materialize_iterator_test.go
+++ b/graph/iterator/materialize_iterator_test.go
@@ -1,0 +1,72 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"errors"
+	"testing"
+
+	//"github.com/google/cayley/graph"
+)
+
+func TestMaterializeIteratorError(t *testing.T) {
+	retErr := errors.New("unique")
+	errIt := newTestIterator(false, retErr)
+
+	// This tests that we properly return 0 results and the error when the
+	// underlying iterator returns an error.
+	mIt := NewMaterialize(errIt)
+
+	if mIt.Next() != false {
+		t.Errorf("Materialize iterator did not pass through underlying 'false'")
+	}
+	if mIt.Err() != retErr {
+		t.Errorf("Materialize iterator did not pass through underlying Err")
+	}
+}
+
+func TestMaterializeIteratorErrorAbort(t *testing.T) {
+	retErr := errors.New("unique")
+	errIt := newTestIterator(false, retErr)
+
+	// This tests that we properly return 0 results and the error when the
+	// underlying iterator is larger than our 'abort at' value, and then
+	// returns an error.
+	or := NewOr()
+	or.AddSubIterator(NewInt64(1, int64(abortMaterializeAt+1)))
+	or.AddSubIterator(errIt)
+
+	mIt := NewMaterialize(or)
+
+	// Should get all the underlying values...
+	for i := 0; i < abortMaterializeAt+1; i++ {
+		if !mIt.Next() {
+			t.Errorf("Materialize iterator returned spurious 'false' on iteration %d", i)
+			return
+		}
+		if mIt.Err() != nil {
+			t.Errorf("Materialize iterator returned non-nil Err on iteration %d", i)
+			return
+		}
+	}
+
+	// ... and then the error value
+	if mIt.Next() != false {
+		t.Errorf("Materialize iterator did not pass through underlying 'false'")
+	}
+	if mIt.Err() != retErr {
+		t.Errorf("Materialize iterator did not pass through underlying Err")
+	}
+}

--- a/graph/iterator/materialize_iterator_test.go
+++ b/graph/iterator/materialize_iterator_test.go
@@ -17,13 +17,11 @@ package iterator
 import (
 	"errors"
 	"testing"
-
-	//"github.com/google/cayley/graph"
 )
 
 func TestMaterializeIteratorError(t *testing.T) {
-	retErr := errors.New("unique")
-	errIt := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	errIt := newTestIterator(false, wantErr)
 
 	// This tests that we properly return 0 results and the error when the
 	// underlying iterator returns an error.
@@ -32,14 +30,14 @@ func TestMaterializeIteratorError(t *testing.T) {
 	if mIt.Next() != false {
 		t.Errorf("Materialize iterator did not pass through underlying 'false'")
 	}
-	if mIt.Err() != retErr {
+	if mIt.Err() != wantErr {
 		t.Errorf("Materialize iterator did not pass through underlying Err")
 	}
 }
 
 func TestMaterializeIteratorErrorAbort(t *testing.T) {
-	retErr := errors.New("unique")
-	errIt := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	errIt := newTestIterator(false, wantErr)
 
 	// This tests that we properly return 0 results and the error when the
 	// underlying iterator is larger than our 'abort at' value, and then
@@ -50,7 +48,7 @@ func TestMaterializeIteratorErrorAbort(t *testing.T) {
 
 	mIt := NewMaterialize(or)
 
-	// Should get all the underlying values...
+	// We should get all the underlying values...
 	for i := 0; i < abortMaterializeAt+1; i++ {
 		if !mIt.Next() {
 			t.Errorf("Materialize iterator returned spurious 'false' on iteration %d", i)
@@ -62,11 +60,11 @@ func TestMaterializeIteratorErrorAbort(t *testing.T) {
 		}
 	}
 
-	// ... and then the error value
+	// ... and then the error value.
 	if mIt.Next() != false {
 		t.Errorf("Materialize iterator did not pass through underlying 'false'")
 	}
-	if mIt.Err() != retErr {
+	if mIt.Err() != wantErr {
 		t.Errorf("Materialize iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -161,3 +161,5 @@ func (it *Not) Describe() graph.Description {
 		Iterators: subIts,
 	}
 }
+
+var _ graph.Nexter = &Not{}

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -123,9 +123,19 @@ func (it *Not) NextPath() bool {
 	return false
 }
 
-func (it *Not) Close() {
-	it.primaryIt.Close()
-	it.allIt.Close()
+// Close closes the primary and all iterators.  If an error occurs, only the
+// first one will be returned.
+func (it *Not) Close() error {
+	var ret error
+
+	if err := it.primaryIt.Close(); err != nil && ret != nil {
+		ret = err
+	}
+	if err := it.allIt.Close(); err != nil && ret != nil {
+		ret = err
+	}
+
+	return ret
 }
 
 func (it *Not) Type() graph.Type { return graph.Not }

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -88,7 +88,7 @@ func (it *Not) Next() bool {
 			return graph.NextLogOut(it, curr, true)
 		}
 	}
-	if err := graph.Err(it.allIt); err != nil {
+	if err := it.allIt.Err(); err != nil {
 		it.err = err
 	}
 	return graph.NextLogOut(it, nil, false)

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -113,6 +113,13 @@ func (it *Not) Contains(val graph.Value) bool {
 		return graph.ContainsLogOut(it, val, false)
 	}
 
+	if err := it.primaryIt.Err(); err != nil {
+		it.err = err
+
+		// Explicitly return 'false', since an error occurred.
+		return false
+	}
+
 	it.result = val
 	return graph.ContainsLogOut(it, val, true)
 }

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -132,9 +132,9 @@ func (it *Not) NextPath() bool {
 func (it *Not) Close() error {
 	err := it.primaryIt.Close()
 
-	err2 := it.allIt.Close()
-	if err2 != nil && err == nil {
-		err = err2
+	_err := it.allIt.Close()
+	if _err != nil && err == nil {
+		err = _err
 	}
 
 	return err

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -12,6 +12,7 @@ type Not struct {
 	primaryIt graph.Iterator
 	allIt     graph.Iterator
 	result    graph.Value
+	err       error
 	runstats  graph.IteratorStats
 }
 
@@ -87,7 +88,14 @@ func (it *Not) Next() bool {
 			return graph.NextLogOut(it, curr, true)
 		}
 	}
+	if err := graph.Err(it.allIt); err != nil {
+		it.err = err
+	}
 	return graph.NextLogOut(it, nil, false)
+}
+
+func (it *Not) Err() error {
+	return it.err
 }
 
 func (it *Not) Result() graph.Value {

--- a/graph/iterator/not_iterator_test.go
+++ b/graph/iterator/not_iterator_test.go
@@ -1,6 +1,7 @@
 package iterator
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -40,5 +41,21 @@ func TestNotIteratorBasics(t *testing.T) {
 		if not.Contains(v) {
 			t.Errorf("Failed to correctly check %d as false", v)
 		}
+	}
+}
+
+func TestNotIteratorErr(t *testing.T) {
+	retErr := errors.New("unique")
+	allIt := newTestIterator(false, retErr)
+
+	toComplementIt := NewFixed(Identity)
+
+	not := NewNot(toComplementIt, allIt)
+
+	if not.Next() != false {
+		t.Errorf("Not iterator did not pass through initial 'false'")
+	}
+	if not.Err() != retErr {
+		t.Errorf("Not iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/not_iterator_test.go
+++ b/graph/iterator/not_iterator_test.go
@@ -45,8 +45,8 @@ func TestNotIteratorBasics(t *testing.T) {
 }
 
 func TestNotIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	allIt := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	allIt := newTestIterator(false, wantErr)
 
 	toComplementIt := NewFixed(Identity)
 
@@ -55,7 +55,7 @@ func TestNotIteratorErr(t *testing.T) {
 	if not.Next() != false {
 		t.Errorf("Not iterator did not pass through initial 'false'")
 	}
-	if not.Err() != retErr {
+	if not.Err() != wantErr {
 		t.Errorf("Not iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -57,8 +57,8 @@ func (it *Optional) Reset() {
 	it.lastCheck = false
 }
 
-func (it *Optional) Close() {
-	it.subIt.Close()
+func (it *Optional) Close() error {
+	return it.subIt.Close()
 }
 
 func (it *Optional) Tagger() *graph.Tagger {

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -156,3 +156,5 @@ func (it *Optional) Stats() graph.IteratorStats {
 func (it *Optional) Size() (int64, bool) {
 	return 0, true
 }
+
+var _ graph.Iterator = &Optional{}

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -90,11 +90,11 @@ func (it *Optional) Result() graph.Value {
 // optional subbranch.
 func (it *Optional) NextPath() bool {
 	if it.lastCheck {
-		ret := it.subIt.NextPath()
-		if !ret {
+		ok := it.subIt.NextPath()
+		if !ok {
 			it.err = it.subIt.Err()
 		}
-		return ret
+		return ok
 	}
 	return false
 }

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -76,6 +76,10 @@ func (it *Optional) ResultTree() *graph.ResultTree {
 	return graph.NewResultTree(it.Result())
 }
 
+func (it *Optional) Err() error {
+	return it.subIt.Err()
+}
+
 func (it *Optional) Result() graph.Value {
 	return it.result
 }

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -38,6 +38,7 @@ type Optional struct {
 	subIt     graph.Iterator
 	lastCheck bool
 	result    graph.Value
+	err       error
 }
 
 // Creates a new optional iterator.
@@ -77,7 +78,7 @@ func (it *Optional) ResultTree() *graph.ResultTree {
 }
 
 func (it *Optional) Err() error {
-	return it.subIt.Err()
+	return it.err
 }
 
 func (it *Optional) Result() graph.Value {
@@ -89,7 +90,11 @@ func (it *Optional) Result() graph.Value {
 // optional subbranch.
 func (it *Optional) NextPath() bool {
 	if it.lastCheck {
-		return it.subIt.NextPath()
+		ret := it.subIt.NextPath()
+		if !ret {
+			it.err = it.subIt.Err()
+		}
+		return ret
 	}
 	return false
 }
@@ -105,6 +110,7 @@ func (it *Optional) SubIterators() []graph.Iterator {
 func (it *Optional) Contains(val graph.Value) bool {
 	checked := it.subIt.Contains(val)
 	it.lastCheck = checked
+	it.err = it.subIt.Err()
 	it.result = val
 	return true
 }

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -33,6 +33,7 @@ type Or struct {
 	itCount           int
 	currentIterator   int
 	result            graph.Value
+	err               error
 }
 
 func NewOr() *Or {
@@ -147,6 +148,11 @@ func (it *Or) Next() bool {
 			return graph.NextLogOut(it, it.result, true)
 		}
 
+		if err := graph.Err(curIt); err != nil {
+			it.err = err
+			return graph.NextLogOut(it, nil, false)
+		}
+
 		if it.isShortCircuiting && !first {
 			break
 		}
@@ -157,6 +163,10 @@ func (it *Or) Next() bool {
 	}
 
 	return graph.NextLogOut(it, nil, false)
+}
+
+func (it *Or) Err() error {
+	return it.err
 }
 
 func (it *Or) Result() graph.Value {

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -259,15 +259,15 @@ func (it *Or) cleanUp() {}
 func (it *Or) Close() error {
 	it.cleanUp()
 
-	var ret error
+	var err error
 	for _, sub := range it.internalIterators {
-		err := sub.Close()
-		if err != nil && ret == nil {
-			ret = err
+		serr := sub.Close()
+		if serr != nil && err == nil {
+			err = serr
 		}
 	}
 
-	return ret
+	return err
 }
 
 func (it *Or) Optimize() (graph.Iterator, bool) {

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -289,3 +289,5 @@ func (it *Or) Stats() graph.IteratorStats {
 
 // Register this as an "or" graph.iterator.
 func (it *Or) Type() graph.Type { return graph.Or }
+
+var _ graph.Nexter = &Or{}

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -148,7 +148,7 @@ func (it *Or) Next() bool {
 			return graph.NextLogOut(it, it.result, true)
 		}
 
-		if err := graph.Err(curIt); err != nil {
+		if err := curIt.Err(); err != nil {
 			it.err = err
 			return graph.NextLogOut(it, nil, false)
 		}

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -241,12 +241,21 @@ func (it *Or) cleanUp() {}
 
 // Close this graph.iterator, and, by extension, close the subiterators.
 // Close should be idempotent, and it follows that if it's subiterators
-// follow this contract, the And follows the contract.
-func (it *Or) Close() {
+// follow this contract, the Or follows the contract.
+//
+// Note: as this potentially involves closing multiple subiterators, only
+// the first error encountered while closing will be reported (if any).
+func (it *Or) Close() error {
 	it.cleanUp()
+
+	var ret error
 	for _, sub := range it.internalIterators {
-		sub.Close()
+		if err := sub.Close(); err != nil && ret != nil {
+			ret = err
+		}
 	}
+
+	return ret
 }
 
 func (it *Or) Optimize() (graph.Iterator, bool) {

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -261,9 +261,9 @@ func (it *Or) Close() error {
 
 	var err error
 	for _, sub := range it.internalIterators {
-		serr := sub.Close()
-		if serr != nil && err == nil {
-			err = serr
+		_err := sub.Close()
+		if _err != nil && err == nil {
+			err = _err
 		}
 	}
 

--- a/graph/iterator/or_iterator_test.go
+++ b/graph/iterator/or_iterator_test.go
@@ -151,8 +151,8 @@ func TestShortCircuitingOrBasics(t *testing.T) {
 }
 
 func TestOrIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	orErr := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	orErr := newTestIterator(false, wantErr)
 
 	fix1 := NewFixed(Identity)
 	fix1.Add(1)
@@ -172,14 +172,14 @@ func TestOrIteratorErr(t *testing.T) {
 	if or.Next() != false {
 		t.Errorf("Or iterator did not pass through underlying 'false'")
 	}
-	if or.Err() != retErr {
+	if or.Err() != wantErr {
 		t.Errorf("Or iterator did not pass through underlying Err")
 	}
 }
 
 func TestShortCircuitOrIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	orErr := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	orErr := newTestIterator(false, wantErr)
 
 	or := NewOr()
 	or.AddSubIterator(orErr)
@@ -188,7 +188,7 @@ func TestShortCircuitOrIteratorErr(t *testing.T) {
 	if or.Next() != false {
 		t.Errorf("Or iterator did not pass through underlying 'false'")
 	}
-	if or.Err() != retErr {
+	if or.Err() != wantErr {
 		t.Errorf("Or iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -92,8 +92,8 @@ func (it *Comparison) doComparison(val graph.Value) bool {
 	}
 }
 
-func (it *Comparison) Close() {
-	it.subIt.Close()
+func (it *Comparison) Close() error {
+	return it.subIt.Close()
 }
 
 func RunIntOp(a int64, op Operator, b int64) bool {

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -51,6 +51,7 @@ type Comparison struct {
 	val    interface{}
 	qs     graph.QuadStore
 	result graph.Value
+	err    error
 }
 
 func NewComparison(sub graph.Iterator, op Operator, val interface{}, qs graph.QuadStore) *Comparison {
@@ -133,7 +134,14 @@ func (it *Comparison) Next() bool {
 			return true
 		}
 	}
+	if err := graph.Err(it.subIt); err != nil {
+		it.err = err
+	}
 	return false
+}
+
+func (it *Comparison) Err() error {
+	return it.err
 }
 
 // DEPRECATED

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -132,9 +132,7 @@ func (it *Comparison) Next() bool {
 			return true
 		}
 	}
-	if err := it.subIt.Err(); err != nil {
-		it.err = err
-	}
+	it.err = it.subIt.Err()
 	return false
 }
 
@@ -175,11 +173,11 @@ func (it *Comparison) Contains(val graph.Value) bool {
 	if !it.doComparison(val) {
 		return false
 	}
-	ret := it.subIt.Contains(val)
-	if !ret {
+	ok := it.subIt.Contains(val)
+	if !ok {
 		it.err = it.subIt.Err()
 	}
-	return ret
+	return ok
 }
 
 // If we failed the check, then the subiterator should not contribute to the result

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -134,7 +134,7 @@ func (it *Comparison) Next() bool {
 			return true
 		}
 	}
-	if err := graph.Err(it.subIt); err != nil {
+	if err := it.subIt.Err(); err != nil {
 		it.err = err
 	}
 	return false

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -155,6 +155,7 @@ func (it *Comparison) NextPath() bool {
 	for {
 		hasNext := it.subIt.NextPath()
 		if !hasNext {
+			it.err = it.subIt.Err()
 			return false
 		}
 		if it.doComparison(it.subIt.Result()) {
@@ -174,7 +175,11 @@ func (it *Comparison) Contains(val graph.Value) bool {
 	if !it.doComparison(val) {
 		return false
 	}
-	return it.subIt.Contains(val)
+	ret := it.subIt.Contains(val)
+	if !ret {
+		it.err = it.subIt.Err()
+	}
+	return ret
 }
 
 // If we failed the check, then the subiterator should not contribute to the result

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -218,3 +218,5 @@ func (it *Comparison) Stats() graph.IteratorStats {
 func (it *Comparison) Size() (int64, bool) {
 	return 0, true
 }
+
+var _ graph.Nexter = &Comparison{}

--- a/graph/iterator/value_comparison_iterator.go
+++ b/graph/iterator/value_comparison_iterator.go
@@ -27,7 +27,6 @@ package iterator
 // In MQL terms, this is the [{"age>=": 21}] concept.
 
 import (
-	"log"
 	"strconv"
 
 	"github.com/google/cayley/graph"
@@ -107,8 +106,7 @@ func RunIntOp(a int64, op Operator, b int64) bool {
 	case compareGTE:
 		return a >= b
 	default:
-		log.Fatal("Unknown operator type")
-		return false
+		panic("Unknown operator type")
 	}
 }
 

--- a/graph/iterator/value_comparison_iterator_test.go
+++ b/graph/iterator/value_comparison_iterator_test.go
@@ -121,15 +121,15 @@ func TestVCIContains(t *testing.T) {
 }
 
 func TestComparisonIteratorErr(t *testing.T) {
-	retErr := errors.New("unique")
-	errIt := newTestIterator(false, retErr)
+	wantErr := errors.New("unique")
+	errIt := newTestIterator(false, wantErr)
 
 	vc := NewComparison(errIt, compareLT, int64(2), simpleStore)
 
 	if vc.Next() != false {
 		t.Errorf("Comparison iterator did not pass through initial 'false'")
 	}
-	if vc.Err() != retErr {
+	if vc.Err() != wantErr {
 		t.Errorf("Comparison iterator did not pass through underlying Err")
 	}
 }

--- a/graph/iterator/value_comparison_iterator_test.go
+++ b/graph/iterator/value_comparison_iterator_test.go
@@ -15,6 +15,7 @@
 package iterator
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -116,5 +117,19 @@ func TestVCIContains(t *testing.T) {
 		if vc.Contains(test.check) != test.expect {
 			t.Errorf("Failed to show %s", test.message)
 		}
+	}
+}
+
+func TestComparisonIteratorErr(t *testing.T) {
+	retErr := errors.New("unique")
+	errIt := newTestIterator(false, retErr)
+
+	vc := NewComparison(errIt, compareLT, int64(2), simpleStore)
+
+	if vc.Next() != false {
+		t.Errorf("Comparison iterator did not pass through initial 'false'")
+	}
+	if vc.Err() != retErr {
+		t.Errorf("Comparison iterator did not pass through underlying Err")
 	}
 }

--- a/graph/leveldb/all_iterator.go
+++ b/graph/leveldb/all_iterator.go
@@ -119,6 +119,10 @@ func (it *AllIterator) Next() bool {
 	return true
 }
 
+func (it *AllIterator) Err() error {
+	return it.iter.Error()
+}
+
 func (it *AllIterator) ResultTree() *graph.ResultTree {
 	return graph.NewResultTree(it.Result())
 }

--- a/graph/leveldb/all_iterator.go
+++ b/graph/leveldb/all_iterator.go
@@ -183,3 +183,5 @@ func (it *AllIterator) Stats() graph.IteratorStats {
 		Size:         s,
 	}
 }
+
+var _ graph.Nexter = &AllIterator{}

--- a/graph/leveldb/all_iterator.go
+++ b/graph/leveldb/all_iterator.go
@@ -145,11 +145,12 @@ func (it *AllIterator) Contains(v graph.Value) bool {
 	return true
 }
 
-func (it *AllIterator) Close() {
+func (it *AllIterator) Close() error {
 	if it.open {
 		it.iter.Release()
 		it.open = false
 	}
+	return nil
 }
 
 func (it *AllIterator) Size() (int64, bool) {

--- a/graph/leveldb/iterator.go
+++ b/graph/leveldb/iterator.go
@@ -109,11 +109,12 @@ func (it *Iterator) Clone() graph.Iterator {
 	return out
 }
 
-func (it *Iterator) Close() {
+func (it *Iterator) Close() error {
 	if it.open {
 		it.iter.Release()
 		it.open = false
 	}
+	return nil
 }
 
 func (it *Iterator) isLiveValue(val []byte) bool {

--- a/graph/leveldb/iterator.go
+++ b/graph/leveldb/iterator.go
@@ -283,3 +283,5 @@ func (it *Iterator) Stats() graph.IteratorStats {
 		Size:         s,
 	}
 }
+
+var _ graph.Nexter = &Iterator{}

--- a/graph/leveldb/iterator.go
+++ b/graph/leveldb/iterator.go
@@ -154,6 +154,10 @@ func (it *Iterator) Next() bool {
 	return false
 }
 
+func (it *Iterator) Err() error {
+	return it.iter.Error()
+}
+
 func (it *Iterator) ResultTree() *graph.ResultTree {
 	return graph.NewResultTree(it.Result())
 }

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -90,7 +90,10 @@ func newQuadStore(path string, options graph.Options) (graph.QuadStore, error) {
 	var err error
 	qs.path = path
 	cacheSize := DefaultCacheSize
-	if val, ok := options.IntKey("cache_size_mb"); ok {
+	val, ok, err := options.IntKey("cache_size_mb")
+	if err != nil {
+		return nil, err
+	} else if ok {
 		cacheSize = val
 	}
 	qs.dbOpts = &opt.Options{
@@ -99,7 +102,10 @@ func newQuadStore(path string, options graph.Options) (graph.QuadStore, error) {
 	qs.dbOpts.ErrorIfMissing = true
 
 	writeBufferSize := DefaultWriteBufferSize
-	if val, ok := options.IntKey("writeBufferSize"); ok {
+	val, ok, err = options.IntKey("writeBufferSize")
+	if err != nil {
+		return nil, err
+	} else if ok {
 		writeBufferSize = val
 	}
 	qs.dbOpts.WriteBuffer = writeBufferSize * opt.MiB

--- a/graph/memstore/all_iterator.go
+++ b/graph/memstore/all_iterator.go
@@ -69,3 +69,6 @@ func (it *quadsAllIterator) Next() bool {
 	}
 	return out
 }
+
+var _ graph.Nexter = &nodesAllIterator{}
+var _ graph.Nexter = &quadsAllIterator{}

--- a/graph/memstore/all_iterator.go
+++ b/graph/memstore/all_iterator.go
@@ -52,6 +52,10 @@ func (it *nodesAllIterator) Next() bool {
 	return true
 }
 
+func (it *nodesAllIterator) Err() error {
+	return nil
+}
+
 func newQuadsAllIterator(qs *QuadStore) *quadsAllIterator {
 	var out quadsAllIterator
 	out.Int64 = *iterator.NewInt64(1, qs.nextQuadID-1)

--- a/graph/memstore/iterator.go
+++ b/graph/memstore/iterator.go
@@ -15,6 +15,7 @@
 package memstore
 
 import (
+	"io"
 	"math"
 
 	"github.com/google/cayley/graph"
@@ -121,7 +122,9 @@ func (it *Iterator) Next() bool {
 	}
 	result, _, err := it.iter.Next()
 	if err != nil {
-		it.err = err
+		if err != io.EOF {
+			it.err = err
+		}
 		return graph.NextLogOut(it, nil, false)
 	}
 	if !it.checkValid(result) {

--- a/graph/memstore/iterator.go
+++ b/graph/memstore/iterator.go
@@ -30,6 +30,7 @@ type Iterator struct {
 	iter   *b.Enumerator
 	data   string
 	result graph.Value
+	err    error
 }
 
 func cmp(a, b int64) int {
@@ -118,6 +119,7 @@ func (it *Iterator) Next() bool {
 	}
 	result, _, err := it.iter.Next()
 	if err != nil {
+		it.err = err
 		return graph.NextLogOut(it, nil, false)
 	}
 	if !it.checkValid(result) {
@@ -125,6 +127,10 @@ func (it *Iterator) Next() bool {
 	}
 	it.result = result
 	return graph.NextLogOut(it, it.result, true)
+}
+
+func (it *Iterator) Err() error {
+	return it.err
 }
 
 func (it *Iterator) ResultTree() *graph.ResultTree {

--- a/graph/memstore/iterator.go
+++ b/graph/memstore/iterator.go
@@ -105,7 +105,9 @@ func (it *Iterator) Clone() graph.Iterator {
 	return m
 }
 
-func (it *Iterator) Close() {}
+func (it *Iterator) Close() error {
+	return nil
+}
 
 func (it *Iterator) checkValid(index int64) bool {
 	return it.qs.log[index].DeletedBy == 0

--- a/graph/memstore/iterator.go
+++ b/graph/memstore/iterator.go
@@ -191,3 +191,5 @@ func (it *Iterator) Stats() graph.IteratorStats {
 		Size:         int64(it.tree.Len()),
 	}
 }
+
+var _ graph.Nexter = &Iterator{}

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -99,8 +99,8 @@ func (it *Iterator) Reset() {
 
 }
 
-func (it *Iterator) Close() {
-	it.iter.Close()
+func (it *Iterator) Close() error {
+	return it.iter.Close()
 }
 
 func (it *Iterator) Tagger() *graph.Tagger {

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -230,3 +230,5 @@ func (it *Iterator) Stats() graph.IteratorStats {
 		Size:         size,
 	}
 }
+
+var _ graph.Nexter = &Iterator{}

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -39,6 +39,7 @@ type Iterator struct {
 	constraint bson.M
 	collection string
 	result     graph.Value
+	err        error
 }
 
 func NewIterator(qs *QuadStore, collection string, d quad.Direction, val graph.Value) *Iterator {
@@ -137,6 +138,7 @@ func (it *Iterator) Next() bool {
 	if !found {
 		err := it.iter.Err()
 		if err != nil {
+			it.err = err
 			glog.Errorln("Error Nexting Iterator: ", err)
 		}
 		return false
@@ -146,6 +148,10 @@ func (it *Iterator) Next() bool {
 	}
 	it.result = result.ID
 	return true
+}
+
+func (it *Iterator) Err() error {
+	return it.err
 }
 
 func (it *Iterator) ResultTree() *graph.ResultTree {

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -57,7 +57,10 @@ func createNewMongoGraph(addr string, options graph.Options) error {
 	}
 	conn.SetSafe(&mgo.Safe{})
 	dbName := DefaultDBName
-	if val, ok := options.StringKey("database_name"); ok {
+	val, ok, err := options.StringKey("database_name")
+	if err != nil {
+		return err
+	} else if ok {
 		dbName = val
 	}
 	db := conn.DB(dbName)
@@ -94,7 +97,10 @@ func newQuadStore(addr string, options graph.Options) (graph.QuadStore, error) {
 	}
 	conn.SetSafe(&mgo.Safe{})
 	dbName := DefaultDBName
-	if val, ok := options.StringKey("database_name"); ok {
+	val, ok, err := options.StringKey("database_name")
+	if err != nil {
+		return nil, err
+	} else if ok {
 		dbName = val
 	}
 	qs.db = conn.DB(dbName)

--- a/graph/primarykey.go
+++ b/graph/primarykey.go
@@ -84,7 +84,7 @@ func (p *PrimaryKey) Int() int64 {
 	case sequential:
 		return p.sequentialID
 	case unique:
-		msg := "UUID cannot be cast to an int64"
+		msg := "UUID cannot be converted to an int64"
 		glog.Errorln(msg)
 		panic(msg)
 	}

--- a/graph/primarykey.go
+++ b/graph/primarykey.go
@@ -84,8 +84,9 @@ func (p *PrimaryKey) Int() int64 {
 	case sequential:
 		return p.sequentialID
 	case unique:
-		glog.Fatal("UUID cannot be cast to an int64")
-		return -1
+		msg := "UUID cannot be cast to an int64"
+		glog.Errorln(msg)
+		panic(msg)
 	}
 	return -1
 }

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -23,8 +23,8 @@ package graph
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/barakmich/glog"
 	"github.com/google/cayley/quad"
 )
 
@@ -103,40 +103,40 @@ type QuadStore interface {
 
 type Options map[string]interface{}
 
-func (d Options) IntKey(key string) (int, bool) {
+func (d Options) IntKey(key string) (int, bool, error) {
 	if val, ok := d[key]; ok {
 		switch vv := val.(type) {
 		case float64:
-			return int(vv), true
+			return int(vv), true, nil
 		default:
-			glog.Fatalln("Invalid", key, "parameter type from config.")
+			return 0, false, fmt.Errorf("Invalid %s parameter type from config: %T", key, val)
 		}
 	}
-	return 0, false
+	return 0, false, nil
 }
 
-func (d Options) StringKey(key string) (string, bool) {
+func (d Options) StringKey(key string) (string, bool, error) {
 	if val, ok := d[key]; ok {
 		switch vv := val.(type) {
 		case string:
-			return vv, true
+			return vv, true, nil
 		default:
-			glog.Fatalln("Invalid", key, "parameter type from config.")
+			return "", false, fmt.Errorf("Invalid %s parameter type from config: %T", key, val)
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
-func (d Options) BoolKey(key string) (bool, bool) {
+func (d Options) BoolKey(key string) (bool, bool, error) {
 	if val, ok := d[key]; ok {
 		switch vv := val.(type) {
 		case bool:
-			return vv, true
+			return vv, true, nil
 		default:
-			glog.Fatalln("Invalid", key, "parameter type from config.")
+			return false, false, fmt.Errorf("Invalid %s parameter type from config: %T", key, val)
 		}
 	}
-	return false, false
+	return false, false, nil
 }
 
 var ErrCannotBulkLoad = errors.New("quadstore: cannot bulk load")

--- a/query/mql/build_iterator.go
+++ b/query/mql/build_iterator.go
@@ -17,7 +17,6 @@ package mql
 import (
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"strings"
 
@@ -93,7 +92,7 @@ func (q *Query) buildIteratorTreeInternal(query interface{}, path Path) (it grap
 		it = q.buildResultIterator(path)
 		optional = true
 	default:
-		log.Fatal("Unknown JSON type?", query)
+		err = fmt.Errorf("Unknown JSON type: %T")
 	}
 	if err != nil {
 		return nil, false, err

--- a/writer/single.go
+++ b/writer/single.go
@@ -32,8 +32,11 @@ type Single struct {
 }
 
 func NewSingleReplication(qs graph.QuadStore, opts graph.Options) (graph.QuadWriter, error) {
-	var ignoreMissing, ignoreDuplicate bool
-	var err error
+	var (
+		ignoreMissing   bool
+		ignoreDuplicate bool
+		err             error
+	)
 
 	if *graph.IgnoreMissing {
 		ignoreMissing = true

--- a/writer/single.go
+++ b/writer/single.go
@@ -33,17 +33,24 @@ type Single struct {
 
 func NewSingleReplication(qs graph.QuadStore, opts graph.Options) (graph.QuadWriter, error) {
 	var ignoreMissing, ignoreDuplicate bool
+	var err error
 
 	if *graph.IgnoreMissing {
 		ignoreMissing = true
 	} else {
-		ignoreMissing, _ = opts.BoolKey("ignore_missing")
+		ignoreMissing, _, err = opts.BoolKey("ignore_missing")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if *graph.IgnoreDup {
 		ignoreDuplicate = true
 	} else {
-		ignoreDuplicate, _ = opts.BoolKey("ignore_duplicate")
+		ignoreDuplicate, _, err = opts.BoolKey("ignore_duplicate")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Single{


### PR DESCRIPTION
This PR does the following:
- As mentioned in #208, add an `Err()` method to all Iterators.
- Adds tests that the various iterators pass through the underlying Err value.
- Makes the `Close()` method on Iterators return an error.
- Remove a bunch of uses of `glog.Fatal*` calls, instead either propagating the errors, or calling `panic` (when it's a programming bug).
- Try to handle errors in other locations that use `Next()`.

cc @kortschak 

Updates #157 