### PR TITLE
store dependencies' versions with godep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,9 @@ go:
   - tip
 
 install:
-  - go get github.com/badgerodon/peg
-  - go get github.com/barakmich/glog
-  - go get github.com/cznic/mathutil
-  - go get github.com/julienschmidt/httprouter
-  - go get github.com/petar/GoLLRB/llrb
-  - go get github.com/peterh/liner
-  - go get github.com/robertkrimen/otto
-  - go get github.com/russross/blackfriday
-  - go get github.com/syndtr/goleveldb/leveldb
-  - go get github.com/syndtr/goleveldb/leveldb/cache
-  - go get github.com/syndtr/goleveldb/leveldb/iterator
-  - go get github.com/syndtr/goleveldb/leveldb/opt
-  - go get github.com/syndtr/goleveldb/leveldb/util
-  - go get github.com/boltdb/bolt
-  - go get gopkg.in/mgo.v2
-  - go get gopkg.in/mgo.v2/bson
-  - go get code.google.com/p/go-uuid/uuid
+  # Install our tracked dependencies
+  - go get github.com/tools/godep
+  - godep restore
 
   # Google App Engine dependencies
   - cd ..
@@ -33,7 +19,7 @@ install:
   - export PATH=$PATH:$PWD/go_appengine/
   - cd cayley
 
-script: 
+script:
   - go test -v ./...
   - goapp test -v ./graph/gaedatastore
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,65 @@
+{
+	"ImportPath": "github.com/google/cayley",
+	"GoVersion": "go1.4.2",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "code.google.com/p/go-uuid/uuid",
+			"Comment": "null-15",
+			"Rev": "35bc42037350f0078e3c974c6ea690f1926603ab"
+		},
+		{
+			"ImportPath": "github.com/badgerodon/peg",
+			"Rev": "9e5f7f4d07ca576562618c23e8abadda278b684f"
+		},
+		{
+			"ImportPath": "github.com/barakmich/glog",
+			"Rev": "fafcb6128a8a2e6360ff034091434d547397d54a"
+		},
+		{
+			"ImportPath": "github.com/boltdb/bolt",
+			"Comment": "v1.0-65-g3b44955",
+			"Rev": "3b449559cf34cbcc74460b59041a4399d3226e5a"
+		},
+		{
+			"ImportPath": "github.com/cznic/mathutil",
+			"Rev": "f9551431b78e71ee24939a1e9d8f49f43898b5cd"
+		},
+		{
+			"ImportPath": "github.com/julienschmidt/httprouter",
+			"Rev": "b59a38004596b696aca7aa2adccfa68760864d86"
+		},
+		{
+			"ImportPath": "github.com/peterh/liner",
+			"Rev": "1bb0d1c1a25ed393d8feb09bab039b2b1b1fbced"
+		},
+		{
+			"ImportPath": "github.com/robertkrimen/otto",
+			"Rev": "d1b4d8ef0e0e4b088c8328c95ca63ab9ebd8fc9d"
+		},
+		{
+			"ImportPath": "github.com/russross/blackfriday",
+			"Comment": "v1.2-54-g17bb799",
+			"Rev": "17bb7999de6cfb791d4f8986cc00b3309b370cdb"
+		},
+		{
+			"ImportPath": "github.com/shurcooL/sanitized_anchor_name",
+			"Rev": "8e87604bec3c645a4eeaee97dfec9f25811ff20d"
+		},
+		{
+			"ImportPath": "github.com/syndtr/goleveldb/leveldb",
+			"Rev": "4875955338b0a434238a31165cb87255ab6e9e4a"
+		},
+		{
+			"ImportPath": "github.com/syndtr/gosnappy/snappy",
+			"Rev": "156a073208e131d7d2e212cb749feae7c339e846"
+		},
+		{
+			"ImportPath": "gopkg.in/mgo.v2",
+			"Comment": "r2015.01.24",
+			"Rev": "c6a7dce14133ccac2dcac3793f1d6e2ef048503a"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.


### PR DESCRIPTION
These dependencies can be loaded into your $GOPATH simply executing
`godep get`. This will allow builds to become reproducible, without
getting in the way of those wanting to consume parts of the project's
source code as a library.

As per the discussion in #234.