### PR TITLE
Mongo Indexed LinksTo

### DIFF
--- a/graph/bolt/bolt_test.go
+++ b/graph/bolt/bolt_test.go
@@ -334,7 +334,7 @@ func TestSetIterator(t *testing.T) {
 	}
 	it.Reset()
 
-	and := iterator.NewAnd()
+	and := iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadsAllIterator())
 	and.AddSubIterator(it)
 
@@ -354,7 +354,7 @@ func TestSetIterator(t *testing.T) {
 		t.Errorf("Failed to get expected results, got:%v expect:%v", got, expect)
 	}
 
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 	and.AddSubIterator(it)
 
@@ -393,7 +393,7 @@ func TestSetIterator(t *testing.T) {
 	it.Reset()
 
 	// Order is important
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 	and.AddSubIterator(it)
 
@@ -406,7 +406,7 @@ func TestSetIterator(t *testing.T) {
 	it.Reset()
 
 	// Order is important
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(it)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 

--- a/graph/gaedatastore/quadstore_test.go
+++ b/graph/gaedatastore/quadstore_test.go
@@ -282,12 +282,12 @@ func TestIteratorsAndNextResultOrderA(t *testing.T) {
 
 	all := qs.NodesAllIterator()
 
-	innerAnd := iterator.NewAnd()
+	innerAnd := iterator.NewAnd(qs)
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, fixed2, quad.Predicate))
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, all, quad.Object))
 
 	hasa := iterator.NewHasA(qs, innerAnd, quad.Subject)
-	outerAnd := iterator.NewAnd()
+	outerAnd := iterator.NewAnd(qs)
 	outerAnd.AddSubIterator(fixed)
 	outerAnd.AddSubIterator(hasa)
 

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -30,7 +30,14 @@ type Tagger struct {
 	fixedTags map[string]Value
 }
 
-type LinkageSet struct {
+// TODO(barakmich): Linkage is general enough that there are places we take
+//the combined arguments `quad.Direction, graph.Value` that it may be worth
+//converting these into Linkages. If nothing else, future indexed iterators may
+//benefit from the shared representation
+
+// Linkage is a union type representing a set of values established for a given
+// quad direction.
+type Linkage struct {
 	Dir    quad.Direction
 	Values []Value
 }

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -30,6 +30,11 @@ type Tagger struct {
 	fixedTags map[string]Value
 }
 
+type LinkageSet struct {
+	Dir    quad.Direction
+	Values []Value
+}
+
 // Add a tag to the iterator.
 func (t *Tagger) Add(tag string) {
 	t.tags = append(t.tags, tag)

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -34,7 +34,8 @@ type And struct {
 	qs                graph.QuadStore
 }
 
-// Creates a new And iterator.
+// NewAnd creates an And iterator. `qs` is only required when needing a handle
+// for QuadStore-specific optimizations, otherwise nil is acceptable.
 func NewAnd(qs graph.QuadStore) *And {
 	return &And{
 		uid:               NextUID(),

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -31,13 +31,15 @@ type And struct {
 	result            graph.Value
 	runstats          graph.IteratorStats
 	err               error
+	qs                graph.QuadStore
 }
 
 // Creates a new And iterator.
-func NewAnd() *And {
+func NewAnd(qs graph.QuadStore) *And {
 	return &And{
 		uid:               NextUID(),
 		internalIterators: make([]graph.Iterator, 0, 20),
+		qs:                qs,
 	}
 }
 
@@ -79,7 +81,7 @@ func (it *And) TagResults(dst map[string]graph.Value) {
 }
 
 func (it *And) Clone() graph.Iterator {
-	and := NewAnd()
+	and := NewAnd(it.qs)
 	and.AddSubIterator(it.primaryIt.Clone())
 	and.tags.CopyFrom(it)
 	for _, sub := range it.internalIterators {

--- a/graph/iterator/and_iterator_optimize.go
+++ b/graph/iterator/and_iterator_optimize.go
@@ -99,10 +99,12 @@ func (it *And) Optimize() (graph.Iterator, bool) {
 	// Ask the graph.QuadStore if we can be replaced. Often times, this is a great
 	// optimization opportunity (there's a fixed iterator underneath us, for
 	// example).
-	newReplacement, hasOne := it.qs.OptimizeIterator(newAnd)
-	if hasOne {
-		newAnd.Close()
-		return newReplacement, true
+	if it.qs != nil {
+		newReplacement, hasOne := it.qs.OptimizeIterator(newAnd)
+		if hasOne {
+			newAnd.Close()
+			return newReplacement, true
+		}
 	}
 
 	return newAnd, true

--- a/graph/iterator/and_iterator_optimize.go
+++ b/graph/iterator/and_iterator_optimize.go
@@ -78,7 +78,7 @@ func (it *And) Optimize() (graph.Iterator, bool) {
 
 	// The easiest thing to do at this point is merely to create a new And iterator
 	// and replace ourselves with our (reordered, optimized) clone.
-	newAnd := NewAnd()
+	newAnd := NewAnd(it.qs)
 
 	// Add the subiterators in order.
 	for _, sub := range its {
@@ -95,6 +95,16 @@ func (it *And) Optimize() (graph.Iterator, bool) {
 	// the new And (they were unchanged upon calling Optimize() on them, at the
 	// start).
 	it.cleanUp()
+
+	// Ask the graph.QuadStore if we can be replaced. Often times, this is a great
+	// optimization opportunity (there's a fixed iterator underneath us, for
+	// example).
+	newReplacement, hasOne := it.qs.OptimizeIterator(newAnd)
+	if hasOne {
+		newAnd.Close()
+		return newReplacement, true
+	}
+
 	return newAnd, true
 }
 

--- a/graph/iterator/and_iterator_optimize_test.go
+++ b/graph/iterator/and_iterator_optimize_test.go
@@ -26,10 +26,14 @@ import (
 )
 
 func TestIteratorPromotion(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	all := NewInt64(1, 3)
 	fixed := NewFixed(Identity)
 	fixed.Add(3)
-	a := NewAnd()
+	a := NewAnd(qs)
 	a.AddSubIterator(all)
 	a.AddSubIterator(fixed)
 	all.Tagger().Add("a")
@@ -51,9 +55,13 @@ func TestIteratorPromotion(t *testing.T) {
 }
 
 func TestNullIteratorAnd(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	all := NewInt64(1, 3)
 	null := NewNull()
-	a := NewAnd()
+	a := NewAnd(qs)
 	a.AddSubIterator(all)
 	a.AddSubIterator(null)
 	newIt, changed := a.Optimize()
@@ -66,11 +74,15 @@ func TestNullIteratorAnd(t *testing.T) {
 }
 
 func TestReorderWithTag(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	all := NewInt64(100, 300)
 	all.Tagger().Add("good")
 	all2 := NewInt64(1, 30000)
 	all2.Tagger().Add("slow")
-	a := NewAnd()
+	a := NewAnd(qs)
 	// Make all2 the default iterator
 	a.AddSubIterator(all2)
 	a.AddSubIterator(all)
@@ -92,11 +104,15 @@ func TestReorderWithTag(t *testing.T) {
 }
 
 func TestAndStatistics(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	all := NewInt64(100, 300)
 	all.Tagger().Add("good")
 	all2 := NewInt64(1, 30000)
 	all2.Tagger().Add("slow")
-	a := NewAnd()
+	a := NewAnd(qs)
 	// Make all2 the default iterator
 	a.AddSubIterator(all2)
 	a.AddSubIterator(all)

--- a/graph/iterator/and_iterator_test.go
+++ b/graph/iterator/and_iterator_test.go
@@ -23,10 +23,14 @@ import (
 
 // Make sure that tags work on the And.
 func TestTag(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	fix1 := NewFixed(Identity)
 	fix1.Add(234)
 	fix1.Tagger().Add("foo")
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(fix1)
 	and.Tagger().Add("bar")
 	out := fix1.Tagger().Tags()
@@ -56,6 +60,10 @@ func TestTag(t *testing.T) {
 
 // Do a simple itersection of fixed values.
 func TestAndAndFixedIterators(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	fix1 := NewFixed(Identity)
 	fix1.Add(1)
 	fix1.Add(2)
@@ -65,7 +73,7 @@ func TestAndAndFixedIterators(t *testing.T) {
 	fix2.Add(3)
 	fix2.Add(4)
 	fix2.Add(5)
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(fix1)
 	and.AddSubIterator(fix2)
 	// Should be as big as smallest subiterator
@@ -94,6 +102,10 @@ func TestAndAndFixedIterators(t *testing.T) {
 // If there's no intersection, the size should still report the same,
 // but there should be nothing to Next()
 func TestNonOverlappingFixedIterators(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	fix1 := NewFixed(Identity)
 	fix1.Add(1)
 	fix1.Add(2)
@@ -103,7 +115,7 @@ func TestNonOverlappingFixedIterators(t *testing.T) {
 	fix2.Add(5)
 	fix2.Add(6)
 	fix2.Add(7)
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(fix1)
 	and.AddSubIterator(fix2)
 	// Should be as big as smallest subiterator
@@ -122,9 +134,13 @@ func TestNonOverlappingFixedIterators(t *testing.T) {
 }
 
 func TestAllIterators(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	all1 := NewInt64(1, 5)
 	all2 := NewInt64(4, 10)
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(all2)
 	and.AddSubIterator(all1)
 
@@ -142,10 +158,14 @@ func TestAllIterators(t *testing.T) {
 }
 
 func TestAndIteratorErr(t *testing.T) {
+	qs := &store{
+		data: []string{},
+		iter: NewFixed(Identity),
+	}
 	wantErr := errors.New("unique")
 	allErr := newTestIterator(false, wantErr)
 
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(allErr)
 	and.AddSubIterator(NewInt64(1, 5))
 

--- a/graph/iterator/query_shape_test.go
+++ b/graph/iterator/query_shape_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func hasaWithTag(qs graph.QuadStore, tag string, target string) *HasA {
-	and := NewAnd()
+	and := NewAnd(qs)
 
 	obj := qs.FixedIterator()
 	obj.Add(qs.ValueOf(target))
@@ -91,7 +91,7 @@ func TestQueryShape(t *testing.T) {
 	}
 
 	// Given a name-of-an-and-iterator's shape.
-	andInternal := NewAnd()
+	andInternal := NewAnd(qs)
 
 	hasa1 := hasaWithTag(qs, "tag1", "cool")
 	hasa1.Tagger().Add("hasa1")
@@ -104,7 +104,7 @@ func TestQueryShape(t *testing.T) {
 	pred := qs.FixedIterator()
 	pred.Add(qs.ValueOf("name"))
 
-	and := NewAnd()
+	and := NewAnd(qs)
 	and.AddSubIterator(NewLinksTo(qs, andInternal, quad.Subject))
 	and.AddSubIterator(NewLinksTo(qs, pred, quad.Predicate))
 

--- a/graph/leveldb/leveldb_test.go
+++ b/graph/leveldb/leveldb_test.go
@@ -333,7 +333,7 @@ func TestSetIterator(t *testing.T) {
 	}
 	it.Reset()
 
-	and := iterator.NewAnd()
+	and := iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadsAllIterator())
 	and.AddSubIterator(it)
 
@@ -353,7 +353,7 @@ func TestSetIterator(t *testing.T) {
 		t.Errorf("Failed to get expected results, got:%v expect:%v", got, expect)
 	}
 
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 	and.AddSubIterator(it)
 
@@ -392,7 +392,7 @@ func TestSetIterator(t *testing.T) {
 	it.Reset()
 
 	// Order is important
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 	and.AddSubIterator(it)
 
@@ -405,7 +405,7 @@ func TestSetIterator(t *testing.T) {
 	it.Reset()
 
 	// Order is important
-	and = iterator.NewAnd()
+	and = iterator.NewAnd(qs)
 	and.AddSubIterator(it)
 	and.AddSubIterator(qs.QuadIterator(quad.Subject, qs.ValueOf("B")))
 

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -108,12 +108,12 @@ func TestIteratorsAndNextResultOrderA(t *testing.T) {
 
 	all := qs.NodesAllIterator()
 
-	innerAnd := iterator.NewAnd()
+	innerAnd := iterator.NewAnd(qs)
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, fixed2, quad.Predicate))
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, all, quad.Object))
 
 	hasa := iterator.NewHasA(qs, innerAnd, quad.Subject)
-	outerAnd := iterator.NewAnd()
+	outerAnd := iterator.NewAnd(qs)
 	outerAnd.AddSubIterator(fixed)
 	outerAnd.AddSubIterator(hasa)
 
@@ -193,7 +193,7 @@ func TestRemoveQuad(t *testing.T) {
 	fixed2 := qs.FixedIterator()
 	fixed2.Add(qs.ValueOf("follows"))
 
-	innerAnd := iterator.NewAnd()
+	innerAnd := iterator.NewAnd(qs)
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, fixed, quad.Subject))
 	innerAnd.AddSubIterator(iterator.NewLinksTo(qs, fixed2, quad.Predicate))
 

--- a/graph/mongo/indexed_linksto.go
+++ b/graph/mongo/indexed_linksto.go
@@ -1,0 +1,264 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongo
+
+import (
+	"github.com/barakmich/glog"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/quad"
+)
+
+type LinksTo struct {
+	uid        uint64
+	collection string
+	tags       graph.Tagger
+	qs         *QuadStore
+	primaryIt  graph.Iterator
+	dir        quad.Direction
+	nextIt     *mgo.Iter
+	result     graph.Value
+	runstats   graph.IteratorStats
+	err        error
+	lset       []graph.LinkageSet
+}
+
+// NewLinksTo constructs a new indexed LinksTo iterator for Mongo around a direction
+// and a subiterator of nodes.
+func NewLinksTo(qs *QuadStore, it graph.Iterator, collection string, d quad.Direction, lset []graph.LinkageSet) *LinksTo {
+	return &LinksTo{
+		uid:        iterator.NextUID(),
+		qs:         qs,
+		primaryIt:  it,
+		dir:        d,
+		nextIt:     nil,
+		lset:       lset,
+		collection: collection,
+	}
+}
+
+func (it *LinksTo) buildIteratorFor(d quad.Direction, val graph.Value) *mgo.Iter {
+	name := it.qs.NameOf(val)
+	constraint := bson.M{d.String(): name}
+	for _, set := range it.lset {
+		var s []string
+		for _, v := range set.Values {
+			s = append(s, it.qs.NameOf(v))
+		}
+		constraint[set.Dir.String()] = bson.M{"$in": s}
+	}
+	glog.V(4).Infof("%#v", constraint)
+	return it.qs.db.C(it.collection).Find(constraint).Iter()
+}
+
+func (it *LinksTo) UID() uint64 {
+	return it.uid
+}
+
+func (it *LinksTo) Tagger() *graph.Tagger {
+	return &it.tags
+}
+
+// Return the direction under consideration.
+func (it *LinksTo) Direction() quad.Direction { return it.dir }
+
+// Tag these results, and our subiterator's results.
+func (it *LinksTo) TagResults(dst map[string]graph.Value) {
+	for _, tag := range it.tags.Tags() {
+		dst[tag] = it.Result()
+	}
+
+	for tag, value := range it.tags.Fixed() {
+		dst[tag] = value
+	}
+
+	it.primaryIt.TagResults(dst)
+}
+
+// DEPRECATED
+func (it *LinksTo) ResultTree() *graph.ResultTree {
+	tree := graph.NewResultTree(it.Result())
+	tree.AddSubtree(it.primaryIt.ResultTree())
+	return tree
+}
+
+// Optimize the LinksTo, by replacing it if it can be.
+func (it *LinksTo) Optimize() (graph.Iterator, bool) {
+	return it, false
+}
+
+func (it *LinksTo) Next() bool {
+	var result struct {
+		ID      string  `bson:"_id"`
+		Added   []int64 `bson:"Added"`
+		Deleted []int64 `bson:"Deleted"`
+	}
+	graph.NextLogIn(it)
+	it.runstats.Next += 1
+	if it.nextIt != nil && it.nextIt.Next(&result) {
+		it.runstats.ContainsNext += 1
+		if it.collection == "quads" && len(result.Added) <= len(result.Deleted) {
+			return it.Next()
+		}
+		it.result = result.ID
+		return graph.NextLogOut(it, it.result, true)
+	}
+
+	if it.nextIt != nil {
+		// If there's an error in the 'next' iterator, we save it and we're done.
+		it.err = it.nextIt.Err()
+		if it.err != nil {
+			return false
+		}
+
+	}
+	// Subiterator is empty, get another one
+	if !graph.Next(it.primaryIt) {
+		// Possibly save error
+		it.err = it.primaryIt.Err()
+
+		// We're out of nodes in our subiterator, so we're done as well.
+		return graph.NextLogOut(it, 0, false)
+	}
+	if it.nextIt != nil {
+		it.nextIt.Close()
+	}
+	it.nextIt = it.buildIteratorFor(it.dir, it.primaryIt.Result())
+
+	// Recurse -- return the first in the next set.
+	return it.Next()
+}
+
+func (it *LinksTo) Err() error {
+	return it.err
+}
+
+func (it *LinksTo) Result() graph.Value {
+	return it.result
+}
+
+func (it *LinksTo) Close() error {
+	var err error
+	if it.nextIt != nil {
+		err = it.nextIt.Close()
+	}
+
+	_err := it.primaryIt.Close()
+	if _err != nil && err == nil {
+		err = _err
+	}
+
+	return err
+}
+
+func (it *LinksTo) NextPath() bool {
+	ok := it.primaryIt.NextPath()
+	if !ok {
+		it.err = it.primaryIt.Err()
+	}
+	return ok
+}
+
+var mongoIndexedLinksToType graph.Type
+
+func init() {
+	mongoIndexedLinksToType = graph.RegisterIterator("mongo-indexed-linksto")
+}
+
+func (it *LinksTo) Type() graph.Type {
+	return mongoIndexedLinksToType
+}
+
+var _ graph.Nexter = &LinksTo{}
+
+func (it *LinksTo) Clone() graph.Iterator {
+	m := NewLinksTo(it.qs, it.primaryIt.Clone(), it.collection, it.dir, it.lset)
+	m.tags.CopyFrom(it)
+	return m
+}
+
+func (it *LinksTo) Contains(val graph.Value) bool {
+	graph.ContainsLogIn(it, val)
+	it.runstats.Contains += 1
+
+	for _, set := range it.lset {
+		dval := it.qs.QuadDirection(val, set.Dir)
+		good := false
+		for _, val := range set.Values {
+			if val == dval {
+				good = true
+				break
+			}
+		}
+		if !good {
+			return graph.ContainsLogOut(it, val, false)
+		}
+	}
+
+	node := it.qs.QuadDirection(val, it.dir)
+	if it.primaryIt.Contains(node) {
+		it.result = val
+		return graph.ContainsLogOut(it, val, true)
+	}
+	it.err = it.primaryIt.Err()
+	return graph.ContainsLogOut(it, val, false)
+}
+
+func (it *LinksTo) Describe() graph.Description {
+	primary := it.primaryIt.Describe()
+	return graph.Description{
+		UID:       it.UID(),
+		Type:      it.Type(),
+		Direction: it.dir,
+		Iterator:  &primary,
+	}
+}
+
+func (it *LinksTo) Reset() {
+	it.primaryIt.Reset()
+	if it.nextIt != nil {
+		it.nextIt.Close()
+	}
+	it.nextIt = nil
+}
+
+// Return a guess as to how big or costly it is to next the iterator.
+func (it *LinksTo) Stats() graph.IteratorStats {
+	subitStats := it.primaryIt.Stats()
+	// TODO(barakmich): These should really come from the quadstore itself
+	fanoutFactor := int64(20)
+	checkConstant := int64(1)
+	nextConstant := int64(2)
+	return graph.IteratorStats{
+		NextCost:     nextConstant + subitStats.NextCost,
+		ContainsCost: checkConstant + subitStats.ContainsCost,
+		Size:         fanoutFactor * subitStats.Size,
+		Next:         it.runstats.Next,
+		Contains:     it.runstats.Contains,
+		ContainsNext: it.runstats.ContainsNext,
+	}
+}
+
+func (it *LinksTo) Size() (int64, bool) {
+	return it.Stats().Size, false
+}
+
+// Return a list containing only our subiterator.
+func (it *LinksTo) SubIterators() []graph.Iterator {
+	return []graph.Iterator{it.primaryIt}
+}

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -198,7 +198,7 @@ func (it *Iterator) Contains(v graph.Value) bool {
 func (it *Iterator) Size() (int64, bool) {
 	if it.size == -1 {
 		var err error
-		it.size, err = it.qs.getSize(it.collection, &it.constraint)
+		it.size, err = it.qs.getSize(it.collection, it.constraint)
 		if err != nil {
 			it.err = err
 		}

--- a/graph/mongo/lru.go
+++ b/graph/mongo/lru.go
@@ -30,7 +30,7 @@ type cache struct {
 
 type kv struct {
 	key   string
-	value string
+	value interface{}
 }
 
 func newCache(size int) *cache {
@@ -41,7 +41,7 @@ func newCache(size int) *cache {
 	return &lru
 }
 
-func (lru *cache) Put(key string, value string) {
+func (lru *cache) Put(key string, value interface{}) {
 	if _, ok := lru.Get(key); ok {
 		return
 	}
@@ -55,7 +55,7 @@ func (lru *cache) Put(key string, value string) {
 	lru.cache[key] = lru.priority.Front()
 }
 
-func (lru *cache) Get(key string) (string, bool) {
+func (lru *cache) Get(key string) (interface{}, bool) {
 	if element, ok := lru.cache[key]; ok {
 		lru.priority.MoveToFront(element)
 		return element.Value.(kv).value, true

--- a/graph/mongo/lru.go
+++ b/graph/mongo/lru.go
@@ -16,6 +16,7 @@ package mongo
 
 import (
 	"container/list"
+	"fmt"
 )
 
 // TODO(kortschak) Reimplement without container/list.
@@ -48,6 +49,9 @@ func (lru *cache) Put(key string, value string) {
 		lru.removeOldest()
 	}
 	lru.priority.PushFront(kv{key: key, value: value})
+	if lru.priority == nil {
+		fmt.Println("wat")
+	}
 	lru.cache[key] = lru.priority.Front()
 }
 

--- a/graph/mongo/lru.go
+++ b/graph/mongo/lru.go
@@ -16,7 +16,6 @@ package mongo
 
 import (
 	"container/list"
-	"fmt"
 )
 
 // TODO(kortschak) Reimplement without container/list.
@@ -49,9 +48,6 @@ func (lru *cache) Put(key string, value interface{}) {
 		lru.removeOldest()
 	}
 	lru.priority.PushFront(kv{key: key, value: value})
-	if lru.priority == nil {
-		fmt.Println("wat")
-	}
 	lru.cache[key] = lru.priority.Front()
 }
 
@@ -60,7 +56,7 @@ func (lru *cache) Get(key string) (interface{}, bool) {
 		lru.priority.MoveToFront(element)
 		return element.Value.(kv).value, true
 	}
-	return "", false
+	return nil, false
 }
 
 func (lru *cache) removeOldest() {

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -380,7 +380,7 @@ func (qs *QuadStore) Type() string {
 	return QuadStoreType
 }
 
-func (qs *QuadStore) getSize(collection string, constraint *bson.M) (int64, error) {
+func (qs *QuadStore) getSize(collection string, constraint bson.M) (int64, error) {
 	var size int
 	var err error
 	bytes, err := bson.Marshal(constraint)

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -382,7 +382,6 @@ func (qs *QuadStore) Type() string {
 
 func (qs *QuadStore) getSize(collection string, constraint bson.M) (int64, error) {
 	var size int
-	var err error
 	bytes, err := bson.Marshal(constraint)
 	if err != nil {
 		glog.Errorf("Couldn't marshal internal constraint")

--- a/graph/mongo/quadstore_iterator_optimize.go
+++ b/graph/mongo/quadstore_iterator_optimize.go
@@ -65,7 +65,7 @@ func (qs *QuadStore) optimizeAndIterator(it *iterator.And) (graph.Iterator, bool
 	}
 	mongostats := firstmongo.Stats()
 
-	lset := []graph.LinkageSet{
+	lset := []graph.Linkage{
 		{
 			Dir:    firstmongo.dir,
 			Values: []graph.Value{qs.ValueOf(firstmongo.name)},

--- a/graph/result_tree_evaluator_test.go
+++ b/graph/result_tree_evaluator_test.go
@@ -33,7 +33,7 @@ func TestSingleIterator(t *testing.T) {
 func TestAndIterator(t *testing.T) {
 	all1 := iterator.NewInt64(1, 3)
 	all2 := iterator.NewInt64(3, 5)
-	and := iterator.NewAnd()
+	and := iterator.NewAnd(nil)
 	and.AddSubIterator(all1)
 	and.AddSubIterator(all2)
 

--- a/query/gremlin/build_iterator.go
+++ b/query/gremlin/build_iterator.go
@@ -133,7 +133,7 @@ func buildInOutIterator(obj *otto.Object, qs graph.QuadStore, base graph.Iterato
 		in, out = out, in
 	}
 	lto := iterator.NewLinksTo(qs, base, in)
-	and := iterator.NewAnd()
+	and := iterator.NewAnd(qs)
 	and.AddSubIterator(iterator.NewLinksTo(qs, predicateNodeIterator, quad.Predicate))
 	and.AddSubIterator(lto)
 	return iterator.NewHasA(qs, and, out)
@@ -182,11 +182,11 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		}
 		predFixed := qs.FixedIterator()
 		predFixed.Add(qs.ValueOf(stringArgs[0]))
-		subAnd := iterator.NewAnd()
+		subAnd := iterator.NewAnd(qs)
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, predFixed, quad.Predicate))
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, all, quad.Object))
 		hasa := iterator.NewHasA(qs, subAnd, quad.Subject)
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(hasa)
 		and.AddSubIterator(subIt)
 		it = and
@@ -202,11 +202,11 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		}
 		predFixed := qs.FixedIterator()
 		predFixed.Add(qs.ValueOf(stringArgs[0]))
-		subAnd := iterator.NewAnd()
+		subAnd := iterator.NewAnd(qs)
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, predFixed, quad.Predicate))
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, all, quad.Subject))
 		hasa := iterator.NewHasA(qs, subAnd, quad.Object)
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(hasa)
 		and.AddSubIterator(subIt)
 		it = and
@@ -220,11 +220,11 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		}
 		predFixed := qs.FixedIterator()
 		predFixed.Add(qs.ValueOf(stringArgs[0]))
-		subAnd := iterator.NewAnd()
+		subAnd := iterator.NewAnd(qs)
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, predFixed, quad.Predicate))
 		subAnd.AddSubIterator(iterator.NewLinksTo(qs, fixed, quad.Object))
 		hasa := iterator.NewHasA(qs, subAnd, quad.Subject)
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(hasa)
 		and.AddSubIterator(subIt)
 		it = and
@@ -238,14 +238,14 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		}
 		argIt := buildIteratorTree(firstArg.Object(), qs)
 
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(subIt)
 		and.AddSubIterator(argIt)
 		it = and
 	case "back":
 		arg, _ := obj.Get("_gremlin_back_chain")
 		argIt := buildIteratorTree(arg.Object(), qs)
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(subIt)
 		and.AddSubIterator(argIt)
 		it = and
@@ -254,7 +254,7 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		for _, name := range stringArgs {
 			fixed.Add(qs.ValueOf(name))
 		}
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(fixed)
 		and.AddSubIterator(subIt)
 		it = and
@@ -311,7 +311,7 @@ func buildIteratorTreeHelper(obj *otto.Object, qs graph.QuadStore, base graph.It
 		toComplementIt := buildIteratorTree(firstArg.Object(), qs)
 		notIt := iterator.NewNot(toComplementIt, allIt)
 
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		and.AddSubIterator(subIt)
 		and.AddSubIterator(notIt)
 		it = and

--- a/query/mql/build_iterator.go
+++ b/query/mql/build_iterator.go
@@ -102,7 +102,7 @@ func (q *Query) buildIteratorTreeInternal(query interface{}, path Path) (it grap
 }
 
 func (q *Query) buildIteratorTreeMapInternal(query map[string]interface{}, path Path) (graph.Iterator, error) {
-	it := iterator.NewAnd()
+	it := iterator.NewAnd(q.ses.qs)
 	it.AddSubIterator(q.ses.qs.NodesAllIterator())
 	var err error
 	err = nil
@@ -136,7 +136,7 @@ func (q *Query) buildIteratorTreeMapInternal(query map[string]interface{}, path 
 			if err != nil {
 				return nil, err
 			}
-			subAnd := iterator.NewAnd()
+			subAnd := iterator.NewAnd(q.ses.qs)
 			predFixed := q.ses.qs.FixedIterator()
 			predFixed.Add(q.ses.qs.ValueOf(pred))
 			subAnd.AddSubIterator(iterator.NewLinksTo(q.ses.qs, predFixed, quad.Predicate))

--- a/query/sexp/parser.go
+++ b/query/sexp/parser.go
@@ -213,7 +213,7 @@ func buildIteratorTree(tree *peg.ExpressionTree, qs graph.QuadStore) graph.Itera
 		return lto
 	case "RootConstraint":
 		constraintCount := 0
-		and := iterator.NewAnd()
+		and := iterator.NewAnd(qs)
 		for _, c := range tree.Children {
 			switch c.Name {
 			case "NodeIdentifier":
@@ -232,7 +232,7 @@ func buildIteratorTree(tree *peg.ExpressionTree, qs graph.QuadStore) graph.Itera
 		var hasa *iterator.HasA
 		topLevelDir := quad.Subject
 		subItDir := quad.Object
-		subAnd := iterator.NewAnd()
+		subAnd := iterator.NewAnd(qs)
 		isOptional := false
 		for _, c := range tree.Children {
 			switch c.Name {


### PR DESCRIPTION
This is actually a more general optimization for a lot of backends, I'm just implementing it on Mongo first because it'll be easy to measure.

Mongo is also doing many size-fetching roundtrips which are unnecessary and slowing down baseline query speed a lot. So that needs to be fixed too.

The optimization is this: currently, while the indexes are built with prefixes, we're not taking advantage of that fact. This reduces the size of a lot of potential sets and speeds up queries a lot as a result.

This is a fairly naive implementation of the similar concept for Mongo. 

Benchmarks are these:
```
$ benchx mongo_indexed.benchstart mongobench.post
benchmark                                   old ns/op      new ns/op      delta	mult
BenchmarkNamePredicate                      25507744       24554295       -3.74%	-1.04x
BenchmarkLargeSetsNoIntersection            915498593      1435804572     +56.83%	+1.57x
BenchmarkVeryLargeSetsSmallIntersection     2224808408     1135664127     -48.95%	-1.96x
BenchmarkHelplessContainsChecker            1011967097     6988584246     +590.59%	+6.91x
BenchmarkHelplessNotContainsFilms           1944054542     175670016      -90.96%	-11.06x
BenchmarkHelplessNotContainsActors          1612441213     1005749592     -37.63%	-1.60x
BenchmarkNetAndSpeed                        817045039      568708805      -30.39%	-1.44x
BenchmarkKeanuAndNet                        521375267      391474443      -24.92%	-1.33x
BenchmarkKeanuAndSpeed                      486171401      369516419      -23.99%	-1.32x
BenchmarkKeanuOther                         1340610433     720032174      -46.29%	-1.86x
BenchmarkKeanuBullockOther                  2191868770     1031652926     -52.93%	-2.12x
```

Before this gets committed, I need to investigate HelplessContainsChecker and it's compatriot HelplessNotContainsChecker -- we've hit a really good optimization there, and, inversely, a large slowdown. Arbitrage opportunity :)