### PR TITLE
Clean up Linkage definition

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -38,9 +38,11 @@ type Tagger struct {
 // Linkage is a union type representing a set of values established for a given
 // quad direction.
 type Linkage struct {
-	Dir    quad.Direction
-	Values []Value
+	Dir   quad.Direction
+	Value Value
 }
+
+// TODO(barakmich): Helper functions as needed, eg, ValuesForDirection(quad.Direction) []Value
 
 // Add a tag to the iterator.
 func (t *Tagger) Add(tag string) {

--- a/graph/mongo/quadstore_iterator_optimize.go
+++ b/graph/mongo/quadstore_iterator_optimize.go
@@ -68,7 +68,7 @@ func (qs *QuadStore) optimizeAndIterator(it *iterator.And) (graph.Iterator, bool
 	lset := []graph.Linkage{
 		{
 			Dir:    mongoIt.dir,
-			Values: []graph.Value{qs.ValueOf(mongoIt.name)},
+			Value: qs.ValueOf(mongoIt.name),
 		},
 	}
 


### PR DESCRIPTION
A linkage is a direction/value pair, and that's all. A set of these can
have helper functions and the like. Cleans up some assumptions of
functionality that isn't useful (yet).

Refactor of a new introduction.