### PR TITLE
Widened visualisation box to 100%

### DIFF
--- a/static/css/query_editor.css
+++ b/static/css/query_editor.css
@@ -40,6 +40,6 @@ line.link {
 }
 
 #visualize {
-  width: 700px;
+  width: 100%;
   height: 700px;
 }


### PR DESCRIPTION
It was very frustrating to use the visualisation feature of Cayley, as the vis box was tiny and waste a lot of space. I widened the space to 100% of the viewable DOM. This makes it much more pleasant to use.

Before:
![screen shot 2015-06-10 at 16 10 43](https://cloud.githubusercontent.com/assets/4482567/8077790/6108fce0-0f8b-11e5-88e6-1b14988b09ac.png)
After:
![screen shot 2015-06-10 at 16 10 31](https://cloud.githubusercontent.com/assets/4482567/8077795/6c50c09c-0f8b-11e5-817f-2befa8ff904f.png)

I have signed the Google CLA.