### PR TITLE
Add transaction (a list of deltas) as a primitive for applying sets o…

### DIFF
--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -72,12 +72,16 @@ type QuadWriter interface {
 	// Add a quad to the store.
 	AddQuad(quad.Quad) error
 
+	// TODO(barakmich): Deprecate in favor of transaction.
 	// Add a set of quads to the store, atomically if possible.
 	AddQuadSet([]quad.Quad) error
 
 	// Removes a quad matching the given one  from the database,
 	// if it exists. Does nothing otherwise.
 	RemoveQuad(quad.Quad) error
+
+	// Apply a set of quad changes
+	ApplyTransaction(*Transaction) error
 
 	// Cleans up replication and closes the writing aspect of the database.
 	Close() error

--- a/graph/transaction.go
+++ b/graph/transaction.go
@@ -1,0 +1,43 @@
+// Copyright 2015 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"github.com/google/cayley/quad"
+)
+
+type Transaction struct {
+	Deltas []Delta
+}
+
+func NewTransaction() *Transaction {
+	return &Transaction{make([]Delta, 0, 5)}
+}
+
+func (t *Transaction) AddQuad(q quad.Quad) {
+	t.Deltas = append(t.Deltas,
+		Delta{
+			Quad:   q,
+			Action: Add,
+		})
+}
+
+func (t *Transaction) RemoveQuad(q quad.Quad) {
+	t.Deltas = append(t.Deltas,
+		Delta{
+			Quad:   q,
+			Action: Delete,
+		})
+}

--- a/imports.go
+++ b/imports.go
@@ -14,10 +14,13 @@ type QuadWriter graph.QuadWriter
 
 type Path path.Path
 
-var StartMorphism = path.StartMorphism
-var StartPath = path.StartPath
+var (
+	StartMorphism = path.StartMorphism
+	StartPath     = path.StartPath
 
-var RawNext = graph.Next
+	RawNext        = graph.Next
+	NewTransaction = graph.NewTransaction
+)
 
 type Handle struct {
 	graph.QuadStore

--- a/writer/single.go
+++ b/writer/single.go
@@ -106,3 +106,12 @@ func (s *Single) Close() error {
 	// Nothing to clean up locally.
 	return nil
 }
+
+func (s *Single) ApplyTransaction(t *graph.Transaction) error {
+	ts := time.Now()
+	for i := 0; i < len(t.Deltas); i++ {
+		t.Deltas[i].ID = s.currentID.Next()
+		t.Deltas[i].Timestamp = ts
+	}
+	return s.qs.ApplyDeltas(t.Deltas, s.ignoreOpts)
+}


### PR DESCRIPTION
…f changes

This will also line up with removing "AddQuadSet" and help with some more intricate types of updates. It's not full-query-capability yet, but we'll need the primitive to do that anyway.