### PR TITLE
Update code.google.com references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,11 @@ install:
 
   # Google App Engine dependencies
   - cd ..
-  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.20.zip
-  - unzip -q go_appengine_sdk_linux_amd64-1.9.20.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.23.zip
+  - unzip -q go_appengine_sdk_linux_amd64-1.9.23.zip
   - export PATH=$PATH:$PWD/go_appengine/
   - cd cayley
 
 script:
   - go test -v ./...
   - goapp test -v ./graph/gaedatastore
-

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,9 +6,9 @@
 	],
 	"Deps": [
 		{
-			"ImportPath": "code.google.com/p/go-uuid/uuid",
+			"ImportPath": "github.com/pborman/uuid",
 			"Comment": "null-15",
-			"Rev": "35bc42037350f0078e3c974c6ea690f1926603ab"
+			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 		},
 		{
 			"ImportPath": "github.com/badgerodon/peg",

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,7 +22,7 @@ All command line flags take precedence over the configuration file.
   Determines the type of the underlying database. Options include:
 
   * `mem`: An in-memory store, based on an initial N-Quads file. Loses all changes when the process exits.
-  * `leveldb`: A persistent on-disk store backed by [LevelDB](http://code.google.com/p/leveldb/).
+  * `leveldb`: A persistent on-disk store backed by [LevelDB](https://github.com/google/leveldb).
   * `bolt`: Stores the graph data on-disk in a [Bolt](http://github.com/boltdb/bolt) file. Uses more disk space and memory than LevelDB for smaller stores, but is often faster to write to and comparable for large ones, with faster average query times.
   * `mongo`: Stores the graph data and indices in a [MongoDB](http://mongodb.org) instance. Slower, as it incurs network traffic, but multiple Cayley instances can disappear and reconnect at will, across a potentially horizontally-scaled store.
 

--- a/graph/primarykey.go
+++ b/graph/primarykey.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"sync"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"github.com/barakmich/glog"
 )
 

--- a/graph/primarykey_test.go
+++ b/graph/primarykey_test.go
@@ -15,7 +15,7 @@
 package graph_test
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	. "github.com/google/cayley/graph"
 	"testing"
 )


### PR DESCRIPTION
With the impending shutdown of code.google.com, the uuid and leveldb references have been pointed to their new homes on github.com
Have signed the CLA