### PR TITLE
travis.yml: bump appengine dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
 
   # Google App Engine dependencies
   - cd ..
-  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.20.zip
-  - unzip -q go_appengine_sdk_linux_amd64-1.9.20.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.23.zip
+  - unzip -q go_appengine_sdk_linux_amd64-1.9.23.zip
   - export PATH=$PATH:$PWD/go_appengine/
   - cd cayley
 


### PR DESCRIPTION
This is currently breaking CI. We should ultimately find a better place
to download this binary, because Google doesn't seem to host old
versions for very long.