### PR TITLE
Fixed multiplier for position of "label" in case of "po" key entry

### DIFF
--- a/graph/leveldb/iterator.go
+++ b/graph/leveldb/iterator.go
@@ -199,7 +199,7 @@ func PositionOf(prefix []byte, d quad.Direction, qs *QuadStore) int {
 		case quad.Object:
 			return hashSize + 2
 		case quad.Label:
-			return hashSize + 2
+			return 3*hashSize + 2
 		}
 	}
 	if bytes.Equal(prefix, []byte("os")) {


### PR DESCRIPTION
in "po", the ordering is {"predicate","object","subject","label"} thus the offset of label is 3*hashSize+2