### PR TITLE
Adds exporting capabilities

### DIFF
--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -50,7 +50,7 @@ var (
 	databasePath       = flag.String("dbpath", "/tmp/testdb", "Path to the database.")
 	databaseBackend    = flag.String("db", "memstore", "Database Backend.")
 	dumpFile           = flag.String("dump", "dbdump.nq", `Quad file to dump the database to (".gz" supported, "-" for stdout).`)
-	dumpType           = flag.String("dump_type", "json", `Quad file format ("json", "nquad").`)
+	dumpType           = flag.String("dump_type", "quad", `Quad file format ("json", "quad", "gml", "graphml").`)
 	replicationBackend = flag.String("replication", "single", "Replication method.")
 	host               = flag.String("host", "127.0.0.1", "Host to listen on (defaults to all).")
 	loadSize           = flag.Int("load_size", 10000, "Size of quadsets to load")

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -219,7 +219,11 @@ func main() {
 			}
 		}
 
-		// internal.Dump()
+		err = internal.Dump(handle.QuadStore, *dumpFile, *dumpType)
+		if err != nil {
+			break
+		}
+
 		handle.Close()
 
 	case "repl":

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -49,6 +49,8 @@ var (
 	configFile         = flag.String("config", "", "Path to an explicit configuration file.")
 	databasePath       = flag.String("dbpath", "/tmp/testdb", "Path to the database.")
 	databaseBackend    = flag.String("db", "memstore", "Database Backend.")
+	dumpFile           = flag.String("dump", "dbdump.nq", `Quad file to dump the database to (".gz" supported, "-" for stdout).`)
+	dumpType           = flag.String("dump_type", "json", `Quad file format ("json", "nquad").`)
 	replicationBackend = flag.String("replication", "single", "Replication method.")
 	host               = flag.String("host", "127.0.0.1", "Host to listen on (defaults to all).")
 	loadSize           = flag.Int("load_size", 10000, "Size of quadsets to load")
@@ -72,6 +74,7 @@ Commands:
   init      Create an empty database.
   load      Bulk-load a quad file into the database.
   http      Serve an HTTP endpoint on the given host and port.
+  dump      Bulk-dump the database into a quad file.
   repl      Drop into a REPL of the given query language.
   version   Version information.
 
@@ -202,6 +205,21 @@ func main() {
 			break
 		}
 
+		handle.Close()
+
+	case "dump":
+		handle, err = db.Open(cfg)
+		if err != nil {
+			break
+		}
+		if !graph.IsPersistent(cfg.DatabaseType) {
+			err = internal.Load(handle.QuadWriter, cfg, *quadFile, *quadType)
+			if err != nil {
+				break
+			}
+		}
+
+		// internal.Dump()
 		handle.Close()
 
 	case "repl":

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -23,6 +23,25 @@ func (exp *Exporter) Count() int32 {
 	return exp.count
 }
 
+func (exp *Exporter) ExportJson() {
+	var jstr []byte 
+	exp.Write("[")
+	it := exp.qstore.QuadsAllIterator()
+	for graph.Next(it) {
+		exp.count++
+		if exp.count > 1 {
+			exp.Write(",")
+		}
+
+		jstr, exp.err = json.Marshal(exp.qstore.Quad(it.Result()))
+		if exp.err != nil {
+			return
+		}
+		exp.Write(string(jstr[:]))
+	}
+	exp.Write("]\n")
+}
+
 //print out the string quoted, escaped
 func (exp *Exporter) WriteEscString(str string) {
 	var esc []byte

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -23,6 +23,25 @@ func (exp *Exporter) Count() int32 {
 	return exp.count
 }
 
+func (exp *Exporter) ExportNquad() {
+	it := exp.qstore.QuadsAllIterator()
+	for graph.Next(it) {
+		exp.count++
+		quad := exp.qstore.Quad(it.Result())
+		
+		exp.WriteEscString(quad.Subject)
+		exp.Write(" ")
+		exp.WriteEscString(quad.Predicate)
+		exp.Write(" ")
+		exp.WriteEscString(quad.Object)
+		if quad.Label != "" {
+			exp.Write(" ")
+			exp.WriteEscString(quad.Label)
+		}
+		exp.Write(" .\n")
+	} 
+}
+
 func (exp *Exporter) ExportJson() {
 	var jstr []byte 
 	exp.Write("[")

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,19 +1,19 @@
 package exporter
 
 import (
-	"io"
 	"encoding/json"
+	"io"
 	"strconv"
 
 	"github.com/google/cayley/graph"
 )
 
 type Exporter struct {
-	wr io.Writer
+	wr     io.Writer
 	qstore graph.QuadStore
-	qi graph.Iterator
-	err error
-	count int
+	qi     graph.Iterator
+	err    error
+	count  int
 }
 
 func NewExporter(writer io.Writer, qstore graph.QuadStore) *Exporter {
@@ -34,7 +34,7 @@ func (exp *Exporter) ExportQuad() {
 	for it := exp.qi; graph.Next(it); {
 		exp.count++
 		quad := exp.qstore.Quad(it.Result())
-		
+
 		exp.WriteEscString(quad.Subject)
 		exp.Write(" ")
 		exp.WriteEscString(quad.Predicate)
@@ -45,11 +45,11 @@ func (exp *Exporter) ExportQuad() {
 			exp.WriteEscString(quad.Label)
 		}
 		exp.Write(" .\n")
-	} 
+	}
 }
 
 func (exp *Exporter) ExportJson() {
-	var jstr []byte 
+	var jstr []byte
 	exp.Write("[")
 	exp.qi.Reset()
 	for it := exp.qi; graph.Next(it); {
@@ -149,28 +149,28 @@ func (exp *Exporter) ExportGraphml() {
 		exp.Write("    <edge source=")
 		exp.WriteEscString(cur.Subject)
 		exp.Write(" target=")
-                exp.WriteEscString(cur.Object)
+		exp.WriteEscString(cur.Object)
 		exp.Write(">\n")
 		exp.Write("      <data key=\"predicate\">")
 		exp.Write(cur.Predicate)
 		exp.Write("</data>\n    </edge>\n")
 		exp.count++
 	}
-	exp.Write("  </graph>\n</graphml>\n");
+	exp.Write("  </graph>\n</graphml>\n")
 }
 
 //print out the string quoted, escaped
 func (exp *Exporter) WriteEscString(str string) {
 	var esc []byte
-    
+
 	if exp.err != nil {
 		return
-	}   
+	}
 	esc, exp.err = json.Marshal(str)
 	if exp.err != nil {
 		return
-	}   
-	_, exp.err = exp.wr.Write(esc)	
+	}
+	_, exp.err = exp.wr.Write(esc)
 }
 
 func (exp *Exporter) Write(str string) {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,0 +1,49 @@
+package exporter
+
+import (
+	"io"
+	"encoding/json"
+
+	"github.com/google/cayley/graph"
+)
+
+type Exporter struct {
+	wr io.Writer
+	qstore graph.QuadStore
+	err error
+	count int32
+}
+
+func NewExporter(writer io.Writer, qstore graph.QuadStore) *Exporter {
+	return &Exporter{wr: writer, qstore: qstore}
+}
+
+// number of records
+func (exp *Exporter) Count() int32 {
+	return exp.count
+}
+
+//print out the string quoted, escaped
+func (exp *Exporter) WriteEscString(str string) {
+	var esc []byte
+    
+	if exp.err != nil {
+		return
+	}   
+	esc, exp.err = json.Marshal(str)
+	if exp.err != nil {
+		return
+	}   
+	_, exp.err = exp.wr.Write(esc)	
+}
+
+func (exp *Exporter) Write(str string) {
+	if exp.err != nil {
+		return
+	}
+	_, exp.err = exp.wr.Write([]byte(str))
+}
+
+func (exp *Exporter) Err() error {
+	return exp.err
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -13,7 +13,7 @@ type Exporter struct {
 	qstore graph.QuadStore
 	qi graph.Iterator
 	err error
-	count int32
+	count int
 }
 
 func NewExporter(writer io.Writer, qstore graph.QuadStore) *Exporter {
@@ -25,7 +25,7 @@ func NewExporterForIterator(writer io.Writer, qstore graph.QuadStore, qi graph.I
 }
 
 // number of records
-func (exp *Exporter) Count() int32 {
+func (exp *Exporter) Count() int {
 	return exp.count
 }
 

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -37,7 +37,7 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 
 	//TODO: add possible support for exporting specific queries only
 	switch typ {
-	case "nquad":
+	case "quad":
 		export.ExportNquad()
 	case "json":
 		export.ExportJson()

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -34,6 +34,11 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 		export.ExportNquad()
 	case "json":
 		export.ExportJson()
+	// gml/graphml experimental
+	case "gml":
+		export.ExportGml()
+	case "graphml":
+		export.ExportGraphml()
 	default:
 		return fmt.Errorf("unknown format %q", typ)
 	}

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/exporter"
+)
+
+// Dump the content of the database into a file based
+// on a few different formats
+func Dump(qs graph.QuadStore, outFile, typ string) error {
+	var f *os.File
+	if outFile == "-" {
+		f = os.Stdout
+	} else {
+		var err error
+		f, err = os.Create(outFile)
+		if err != nil {
+			return fmt.Errorf("could not open file %q: %v", outFile, err)
+		}
+		defer f.Close()
+		fmt.Printf("dumping db to file %q\n", outFile)
+	}
+
+	export := exporter.NewExporter(f, qs)
+	if export.Err() != nil {
+		return export.Err()
+	}
+
+        if outFile != "-" {
+		fmt.Printf("%d entries were written\n", export.Count())
+	}
+	return nil
+}

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -28,6 +28,7 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 	if export.Err() != nil {
 		return export.Err()
 	}
+	export.ExportJson()
 
         if outFile != "-" {
 		fmt.Printf("%d entries were written\n", export.Count())

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 	"os"
+	"compress/gzip"
+	"path/filepath"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/exporter"
@@ -24,11 +26,16 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 		fmt.Printf("dumping db to file %q\n", outFile)
 	}
 
-	export := exporter.NewExporter(f, qs)
-	if export.Err() != nil {
-		return export.Err()
+	var export *exporter.Exporter
+	if filepath.Ext(outFile) == ".gz" {
+		gzip := gzip.NewWriter(f)
+		defer gzip.Close()
+		export = exporter.NewExporter(gzip, qs)
+	} else {
+		export = exporter.NewExporter(f, qs)
 	}
 
+	//TODO: add possible support for exporting specific queries only
 	switch typ {
 	case "nquad":
 		export.ExportNquad()

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -28,7 +28,19 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 	if export.Err() != nil {
 		return export.Err()
 	}
-	export.ExportJson()
+
+	switch typ {
+	case "nquad":
+		export.ExportNquad()
+	case "json":
+		export.ExportJson()
+	default:
+		return fmt.Errorf("unknown format %q", typ)
+	}
+	
+	if export.Err() != nil {
+		return export.Err()
+	}
 
         if outFile != "-" {
 		fmt.Printf("%d entries were written\n", export.Count())

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -38,7 +38,7 @@ func Dump(qs graph.QuadStore, outFile, typ string) error {
 	//TODO: add possible support for exporting specific queries only
 	switch typ {
 	case "quad":
-		export.ExportNquad()
+		export.ExportQuad()
 	case "json":
 		export.ExportJson()
 	// gml/graphml experimental


### PR DESCRIPTION
My first attempt at writing/modifying go code, so forgive possible egregious idiomatic golang mistakes. So here it is.

PR Adds exporting capabilities for backup/migration/visualization

    ./cayley dump -config=foo.cfg -dump=backup.nq -dump_type=nquad

**Types:** nquad / json / [gml](https://en.wikipedia.org/wiki/Graph_Modelling_Language) / [graphml](https://en.wikipedia.org/wiki/GraphML) (last two experimental)
**Output:** to file, gzipped file (when .gz extension used), or "-" for stdout

Solves #176 too.