### PR TITLE
Typo fix when building cayley from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you prefer to build from source, see the documentation on the wiki at [How to
 mkdir -p ~/cayley && cd ~/cayley
 export GOPATH=`pwd`
 export PATH=$PATH:~/cayley/bin
-mkdir -p bin pkg sr/github.com/google
+mkdir -p bin pkg src/github.com/google
 cd src/github.com/google
 git clone https://github.com/google/cayley
 cd cayley


### PR DESCRIPTION
Easy typo fix in build script. When creating a directory tree to host google project a 'c' was missing on 'src/github.com/google'

See change in line 42 of README.md