### PR TITLE
sql: Combine AND(Fixed, SQL) into a single IN clause, reducing roundtrips.…

### DIFF
--- a/graph/sql/sql_link_iterator.go
+++ b/graph/sql/sql_link_iterator.go
@@ -224,9 +224,8 @@ func (l *SQLLinkIterator) buildWhere() (string, []string) {
 			q = append(q, fmt.Sprintf("%s.%s_hash = ?", l.tableName, c.dir))
 			vals = append(vals, hashOf(c.vals[0]))
 		} else if len(c.vals) > 1 {
-			subq := fmt.Sprintf("%s.%s_hash IN ", l.tableName, c.dir)
 			valslots := strings.Join(strings.Split(strings.Repeat("?", len(c.vals)), ""), ", ")
-			subq += fmt.Sprintf("(%s)", valslots)
+			subq := fmt.Sprintf("%s.%s_hash IN (%s)", l.tableName, c.dir, valslots)
 			q = append(q, subq)
 			for _, v := range c.vals {
 				vals = append(vals, hashOf(v))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -394,6 +394,19 @@ var benchmarkQueries = []struct {
 			map[string]string{"costar1_actor": "Sandra Bullock", "costar1_movie": "In Love and War", "costar2_actor": "Keanu Reeves", "costar2_movie": "The Lake House", "id": "Sandra Bullock"},
 		},
 	},
+	{
+		message: "Save a number of predicates around a set of nodes",
+		query: `
+		g.V("_:9037", "_:49278", "_:44112", "_:44709", "_:43382").Save("/film/performance/character", "char").Save("/film/performance/actor", "act").SaveR("/film/film/starring", "film").All()
+		`,
+		expect: []interface{}{
+			map[string]string{"act": "/en/humphrey_bogart", "char": "Rick Blaine", "film": "/en/casablanca_1942", "id": "_:9037"},
+			map[string]string{"act": "/en/humphrey_bogart", "char": "Sam Spade", "film": "/en/the_maltese_falcon_1941", "id": "_:49278"},
+			map[string]string{"act": "/en/humphrey_bogart", "char": "Philip Marlowe", "film": "/en/the_big_sleep_1946", "id": "_:44112"},
+			map[string]string{"act": "/en/humphrey_bogart", "char": "Captain Queeg", "film": "/en/the_caine_mutiny_1954", "id": "_:44709"},
+			map[string]string{"act": "/en/humphrey_bogart", "char": "Charlie Allnut", "film": "/en/the_african_queen", "id": "_:43382"},
+		},
+	},
 }
 
 const common = `
@@ -664,6 +677,10 @@ func BenchmarkKeanuOther(b *testing.B) {
 
 func BenchmarkKeanuBullockOther(b *testing.B) {
 	runBench(10, b)
+}
+
+func BenchmarkSaveBogartPerformances(b *testing.B) {
+	runBench(11, b)
 }
 
 // reader is a test helper to filter non-io.Reader methods from the contained io.Reader.


### PR DESCRIPTION
… Add a test and benchmark.

Benchmarks on localhost:
The new test before:
```
BenchmarkSaveBogartPerformances	     200	   5916752 ns/op
```

The new test after:
```
BenchmarkSaveBogartPerformances	     500	   3431612 ns/op
```

So about 2x. Expect a bigger win when talking to a remote server.

Fixes #314 