### PR TITLE
Fix NPE in SQL Quadstore

### DIFF
--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -216,10 +216,12 @@ func (qs *QuadStore) runTxPostgres(tx *sql.Tx, in []graph.Delta, opts graph.Igno
 				d.Quad.Subject, d.Quad.Predicate, d.Quad.Object, d.Quad.Label)
 			if err != nil {
 				glog.Errorf("couldn't exec DELETE statement: %v", err)
+				return err
 			}
 			affected, err := result.RowsAffected()
 			if err != nil {
 				glog.Errorf("couldn't get DELETE RowsAffected: %v", err)
+				return err
 			}
 			if affected != 1 && !opts.IgnoreMissing {
 				return errors.New("deleting non-existent triple; rolling back")


### PR DESCRIPTION
When `tx.Exec` fails and an error is returned, result is nil. Thus, `result.RowsAffected()` panics.

* Add a missing return statement in the error test.
* Add a second missing return statement just below to return the proper error message if we can't execute `RowsAffected` instead of saying that the triple doesn't exist.

(CLA Accepted)