### PR TITLE
query/gremlin: Refactor in terms of graph/path

### DIFF
--- a/data/testdata.nq
+++ b/data/testdata.nq
@@ -9,3 +9,5 @@
 <emily> <follows> <fred> .
 <fred> <follows> <greg> .
 <greg> <status> "cool_person" .
+<predicates> <are> <follows> .
+<predicates> <are> <status> .

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -137,6 +137,28 @@ func inMorphism(via ...interface{}) morphism {
 	}
 }
 
+// predicatesMorphism iterates to the uniqified set of predicates from
+// the given set of nodes in the path.
+func predicatesMorphism(isIn bool) morphism {
+	m := morphism{
+		Name:     "out_predicates",
+		Reversal: func() morphism { panic("not implemented: need a function from predicates to their associated edges") },
+		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *context) (graph.Iterator, *context) {
+			dir := quad.Subject
+			if isIn {
+				dir = quad.Object
+			}
+			lto := iterator.NewLinksTo(qs, in, dir)
+			hasa := iterator.NewHasA(qs, lto, quad.Predicate)
+			return iterator.NewUnique(hasa), ctx
+		},
+	}
+	if isIn {
+		m.Name = "in_predicates"
+	}
+	return m
+}
+
 // iteratorMorphism simply tacks the input iterator onto the chain.
 func iteratorMorphism(it graph.Iterator) morphism {
 	return morphism{

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -20,13 +20,35 @@ type applyMorphism func(graph.QuadStore, graph.Iterator, *context) (graph.Iterat
 
 type morphism struct {
 	Name     string
-	Reversal func() morphism
+	Reversal func(*context) (morphism, *context)
 	Apply    applyMorphism
 	tags     []string
+	context  context
 }
 
+// context allows a high-level change to the way paths are constructed. Some
+// functions may change the context, causing following chained calls to act
+// cdifferently.
+//
+// In a sense, this is a global state which can be changed as the path
+// continues. And as with dealing with any global state, care should be taken:
+//
+// When modifying the context in Apply(), please copy the passed struct,
+// modifying the relevant fields if need be (or pass the given context onward).
+//
+// Under Reversal(), any functions that wish to change the context should
+// appropriately change the passed context (that is, the context that came after
+// them will now be what the application of the function would have been) and
+// then yield a pointer to their own member context as the return value.
+//
+// For more examples, look at the morphisms which claim the individual fields.
 type context struct {
-	labelSet Path
+	// Represents the path to the limiting set of labels that should be considered under traversal.
+	// inMorphism, outMorphism, et al should constrain edges by this set.
+	// A nil in this field represents all labels.
+	//
+	// Claimed by the withLabel morphism
+	labelSet *Path
 }
 
 // Path represents either a morphism (a pre-defined path stored for later use),
@@ -34,7 +56,7 @@ type context struct {
 type Path struct {
 	stack       []morphism
 	qs          graph.QuadStore // Optionally. A nil qs is equivalent to a morphism.
-	baseContext *context
+	baseContext context
 }
 
 // IsMorphism returns whether this Path is a morphism.
@@ -74,8 +96,11 @@ func NewPath(qs graph.QuadStore) *Path {
 // Reverse returns a new Path that is the reverse of the current one.
 func (p *Path) Reverse() *Path {
 	newPath := NewPath(p.qs)
+	ctx := &newPath.baseContext
 	for i := len(p.stack) - 1; i >= 0; i-- {
-		newPath.stack = append(newPath.stack, p.stack[i].Reversal())
+		var revMorphism morphism
+		revMorphism, ctx = p.stack[i].Reversal(ctx)
+		newPath.stack = append(newPath.stack, revMorphism)
 	}
 	return newPath
 }
@@ -153,10 +178,10 @@ func (p *Path) Both(via ...interface{}) *Path {
 // predicates from the current nodes.
 //
 // For example:
-// // Returns a list of predicates valid from "bob"
-// //
-// // Will return []string{"follows"} if there are any things that "follow" Bob
-// StartPath(qs, "bob").InPredicates()
+//  // Returns a list of predicates valid from "bob"
+//  //
+//  // Will return []string{"follows"} if there are any things that "follow" Bob
+//  StartPath(qs, "bob").InPredicates()
 func (p *Path) InPredicates() *Path {
 	p.stack = append(p.stack, predicatesMorphism(true))
 	return p
@@ -166,11 +191,11 @@ func (p *Path) InPredicates() *Path {
 // predicates from the current nodes.
 //
 // For example:
-// // Returns a list of predicates valid from "bob"
-// //
-// // Will return []string{"follows", "status"} if there are edges from "bob"
-// // labelled "follows", and edges from "bob" that describe his "status".
-// StartPath(qs, "bob").OutPredicates()
+//  // Returns a list of predicates valid from "bob"
+//  //
+//  // Will return []string{"follows", "status"} if there are edges from "bob"
+//  // labelled "follows", and edges from "bob" that describe his "status".
+//  StartPath(qs, "bob").OutPredicates()
 func (p *Path) OutPredicates() *Path {
 	p.stack = append(p.stack, predicatesMorphism(false))
 	return p
@@ -220,8 +245,8 @@ func (p *Path) FollowReverse(path *Path) *Path {
 // tag, and propagate that to the result set.
 //
 // For example:
-// // Will return []map[string]string{{"social_status: "cool"}}
-// StartPath(qs, "B").Save("status", "social_status"
+//  // Will return []map[string]string{{"social_status: "cool"}}
+//  StartPath(qs, "B").Save("status", "social_status"
 func (p *Path) Save(via interface{}, tag string) *Path {
 	p.stack = append(p.stack, saveMorphism(via, tag))
 	return p
@@ -244,12 +269,12 @@ func (p *Path) Has(via interface{}, nodes ...string) *Path {
 // Back returns to a previously tagged place in the path. Any constraints applied after the Tag will remain in effect, but traversal continues from the tagged point instead, not from the end of the chain.
 //
 // For example:
-// // Will return "bob" iff "bob" is cool
-// StartPath(qs, "bob").Tag("person_tag").Out("status").Is("cool").Back("person_tag")
+//  // Will return "bob" iff "bob" is cool
+//  StartPath(qs, "bob").Tag("person_tag").Out("status").Is("cool").Back("person_tag")
 func (p *Path) Back(tag string) *Path {
 	newPath := NewPath(p.qs)
 	i := len(p.stack) - 1
-
+	ctx := &newPath.baseContext
 	for {
 		if i < 0 {
 			return p.Reverse()
@@ -263,7 +288,9 @@ func (p *Path) Back(tag string) *Path {
 				}
 			}
 		}
-		newPath.stack = append(newPath.stack, p.stack[i].Reversal())
+		var revMorphism morphism
+		revMorphism, ctx = p.stack[i].Reversal(ctx)
+		newPath.stack = append(newPath.stack, revMorphism)
 		i--
 	}
 }
@@ -291,7 +318,7 @@ func (p *Path) BuildIteratorOn(qs graph.QuadStore) graph.Iterator {
 func (p *Path) Morphism() graph.ApplyMorphism {
 	return func(qs graph.QuadStore, it graph.Iterator) graph.Iterator {
 		i := it.Clone()
-		ctx := p.baseContext
+		ctx := &p.baseContext
 		for _, m := range p.stack {
 			i, ctx = m.Apply(qs, i, ctx)
 		}

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -98,11 +98,6 @@ func (p *Path) Tag(tags ...string) *Path {
 	return p
 }
 
-// As is a synonym for Tag.
-func (p *Path) As(tags ...string) *Path {
-	return p.Tag(tags...)
-}
-
 // Out updates this Path to represent the nodes that are adjacent to the
 // current nodes, via the given outbound predicate.
 //
@@ -128,6 +123,33 @@ func (p *Path) Out(via ...interface{}) *Path {
 //  StartPath(qs, "B").In("follows")
 func (p *Path) In(via ...interface{}) *Path {
 	p.stack = append(p.stack, inMorphism(via...))
+	return p
+}
+
+// InPredicates updates this path to represent the nodes of the valid inbound
+// predicates from the current nodes.
+//
+// For example:
+// // Returns a list of predicates valid from "bob"
+// //
+// // Will return []string{"follows"} if there are any things that "follow" Bob
+// StartPath(qs, "bob").InPredicates()
+func (p *Path) InPredicates() *Path {
+	p.stack = append(p.stack, predicatesMorphism(true))
+	return p
+}
+
+// OutPredicates updates this path to represent the nodes of the valid inbound
+// predicates from the current nodes.
+//
+// For example:
+// // Returns a list of predicates valid from "bob"
+// //
+// // Will return []string{"follows", "status"} if there are edges from "bob"
+// // labelled "follows", and edges from "bob" that describe his "status".
+// StartPath(qs, "bob").OutPredicates()
+func (p *Path) OutPredicates() *Path {
+	p.stack = append(p.stack, predicatesMorphism(false))
 	return p
 }
 
@@ -221,7 +243,6 @@ func (p *Path) Back(tag string) *Path {
 		newPath.stack = append(newPath.stack, p.stack[i].Reversal())
 		i--
 	}
-
 }
 
 // BuildIterator returns an iterator from this given Path.  Note that you must

--- a/graph/path/path_test.go
+++ b/graph/path/path_test.go
@@ -15,12 +15,15 @@
 package path
 
 import (
+	"io"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/quad"
+	"github.com/google/cayley/quad/cquads"
 
 	_ "github.com/google/cayley/graph/memstore"
 	_ "github.com/google/cayley/writer"
@@ -28,38 +31,43 @@ import (
 
 // This is a simple test graph.
 //
-//    +---+                        +---+
-//    | A |-------               ->| F |<--
-//    +---+       \------>+---+-/  +---+   \--+---+
-//                 ------>|#B#|      |        | E |
-//    +---+-------/      >+---+      |        +---+
-//    | C |             /            v
-//    +---+           -/           +---+
-//      ----    +---+/             |#G#|
-//          \-->|#D#|------------->+---+
-//              +---+
-//
+//  +-------+                        +------+
+//  | alice |-----                 ->| fred |<--
+//  +-------+     \---->+-------+-/  +------+   \-+-------+
+//                ----->| #bob# |       |         | emily |
+//  +---------+--/  --->+-------+       |         +-------+
+//  | charlie |    /                    v
+//  +---------+   /                  +--------+
+//    \---    +--------+             | #greg# |
+//        \-->| #dani# |------------>+--------+
+//            +--------+
 
-var simpleGraph = []quad.Quad{
-	{"A", "follows", "B", ""},
-	{"C", "follows", "B", ""},
-	{"C", "follows", "D", ""},
-	{"D", "follows", "B", ""},
-	{"B", "follows", "F", ""},
-	{"F", "follows", "G", ""},
-	{"D", "follows", "G", ""},
-	{"E", "follows", "F", ""},
-	{"B", "status", "cool", "status_graph"},
-	{"D", "status", "cool", "status_graph"},
-	{"G", "status", "cool", "status_graph"},
-	{"predicates", "are", "follows", ""},
-	{"predicates", "are", "status", ""},
+func loadGraph(path string, t testing.TB) []quad.Quad {
+	var r io.Reader
+	var simpleGraph []quad.Quad
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open %q: %v", path, err)
+	}
+	defer f.Close()
+	r = f
+
+	dec := cquads.NewDecoder(r)
+	q1, err := dec.Unmarshal()
+	if err != nil {
+		t.Fatalf("Failed to Unmarshal: %v", err)
+	}
+	for ; err == nil; q1, err = dec.Unmarshal() {
+		simpleGraph = append(simpleGraph, q1)
+	}
+	return simpleGraph
 }
 
-func makeTestStore(data []quad.Quad) graph.QuadStore {
+func makeTestStore(t testing.TB) graph.QuadStore {
+	simpleGraph := loadGraph("../../data/testdata.nq", t)
 	qs, _ := graph.NewQuadStore("memstore", "", nil)
 	w, _ := graph.NewQuadWriter("single", qs, nil)
-	for _, t := range data {
+	for _, t := range simpleGraph {
 		w.AddQuad(t)
 	}
 	return qs
@@ -104,89 +112,100 @@ func testSet(qs graph.QuadStore) []test {
 	return []test{
 		{
 			message: "use out",
-			path:    StartPath(qs, "A").Out("follows"),
-			expect:  []string{"B"},
+			path:    StartPath(qs, "alice").Out("follows"),
+			expect:  []string{"bob"},
 		},
 		{
 			message: "use in",
-			path:    StartPath(qs, "B").In("follows"),
-			expect:  []string{"A", "C", "D"},
+			path:    StartPath(qs, "bob").In("follows"),
+			expect:  []string{"alice", "charlie", "dani"},
 		},
 		{
 			message: "use path Out",
-			path:    StartPath(qs, "B").Out(StartPath(qs, "predicates").Out("are")),
-			expect:  []string{"F", "cool"},
+			path:    StartPath(qs, "bob").Out(StartPath(qs, "predicates").Out("are")),
+			expect:  []string{"fred", "cool_person"},
 		},
 		{
 			message: "use And",
-			path: StartPath(qs, "D").Out("follows").And(
-				StartPath(qs, "C").Out("follows")),
-			expect: []string{"B"},
+			path: StartPath(qs, "dani").Out("follows").And(
+				StartPath(qs, "charlie").Out("follows")),
+			expect: []string{"bob"},
 		},
 		{
 			message: "use Or",
-			path: StartPath(qs, "F").Out("follows").Or(
-				StartPath(qs, "A").Out("follows")),
-			expect: []string{"B", "G"},
+			path: StartPath(qs, "fred").Out("follows").Or(
+				StartPath(qs, "alice").Out("follows")),
+			expect: []string{"bob", "greg"},
 		},
 		{
 			message: "implicit All",
 			path:    StartPath(qs),
-			expect:  []string{"A", "B", "C", "D", "E", "F", "G", "follows", "status", "cool", "status_graph", "predicates", "are"},
+			expect:  []string{"alice", "bob", "charlie", "dani", "emily", "fred", "greg", "follows", "status", "cool_person", "predicates", "are"},
 		},
 		{
 			message: "follow",
-			path:    StartPath(qs, "C").Follow(StartMorphism().Out("follows").Out("follows")),
-			expect:  []string{"B", "F", "G"},
+			path:    StartPath(qs, "charlie").Follow(StartMorphism().Out("follows").Out("follows")),
+			expect:  []string{"bob", "fred", "greg"},
 		},
 		{
 			message: "followR",
-			path:    StartPath(qs, "F").FollowReverse(StartMorphism().Out("follows").Out("follows")),
-			expect:  []string{"A", "C", "D"},
+			path:    StartPath(qs, "fred").FollowReverse(StartMorphism().Out("follows").Out("follows")),
+			expect:  []string{"alice", "charlie", "dani"},
 		},
 		{
 			message: "is, tag, instead of FollowR",
-			path:    StartPath(qs).Tag("first").Follow(StartMorphism().Out("follows").Out("follows")).Is("F"),
-			expect:  []string{"A", "C", "D"},
+			path:    StartPath(qs).Tag("first").Follow(StartMorphism().Out("follows").Out("follows")).Is("fred"),
+			expect:  []string{"alice", "charlie", "dani"},
 			tag:     "first",
 		},
 		{
 			message: "use Except to filter out a single vertex",
-			path:    StartPath(qs, "A", "B").Except(StartPath(qs, "A")),
-			expect:  []string{"B"},
+			path:    StartPath(qs, "alice", "bob").Except(StartPath(qs, "alice")),
+			expect:  []string{"bob"},
 		},
 		{
 			message: "use chained Except",
-			path:    StartPath(qs, "A", "B", "C").Except(StartPath(qs, "B")).Except(StartPath(qs, "A")),
-			expect:  []string{"C"},
+			path:    StartPath(qs, "alice", "bob", "charlie").Except(StartPath(qs, "bob")).Except(StartPath(qs, "alice")),
+			expect:  []string{"charlie"},
 		},
 		{
 			message: "show a simple save",
 			path:    StartPath(qs).Save("status", "somecool"),
 			tag:     "somecool",
-			expect:  []string{"cool", "cool", "cool"},
+			expect:  []string{"cool_person", "cool_person", "cool_person"},
 		},
 		{
 			message: "show a simple saveR",
-			path:    StartPath(qs, "cool").SaveReverse("status", "who"),
+			path:    StartPath(qs, "cool_person").SaveReverse("status", "who"),
 			tag:     "who",
-			expect:  []string{"G", "D", "B"},
+			expect:  []string{"greg", "dani", "bob"},
 		},
 		{
 			message: "show a simple Has",
-			path:    StartPath(qs).Has("status", "cool"),
-			expect:  []string{"G", "D", "B"},
+			path:    StartPath(qs).Has("status", "cool_person"),
+			expect:  []string{"greg", "dani", "bob"},
 		},
 		{
 			message: "show a double Has",
-			path:    StartPath(qs).Has("status", "cool").Has("follows", "F"),
-			expect:  []string{"B"},
+			path:    StartPath(qs).Has("status", "cool_person").Has("follows", "fred"),
+			expect:  []string{"bob"},
+		},
+		{
+			message: "use .Tag()-.Is()-.Back()",
+			path:    StartPath(qs, "bob").In("follows").Tag("foo").Out("status").Is("cool_person").Back("foo"),
+			expect:  []string{"dani"},
+		},
+		{
+			message: "do multiple .Back()s",
+			path:    StartPath(qs, "emily").Out("follows").As("f").Out("follows").Out("status").Is("cool_person").Back("f").In("follows").In("follows").As("acd").Out("status").Is("cool_person").Back("f"),
+			tag:     "acd",
+			expect:  []string{"dani"},
 		},
 	}
 }
 
 func TestMorphisms(t *testing.T) {
-	qs := makeTestStore(simpleGraph)
+	qs := makeTestStore(t)
 	for _, test := range testSet(qs) {
 		var got []string
 		if test.tag == "" {

--- a/graph/path/path_test.go
+++ b/graph/path/path_test.go
@@ -108,6 +108,12 @@ type test struct {
 	tag     string
 }
 
+// Define morphisms without a QuadStore
+
+var (
+	grandfollows = StartMorphism().Out("follows").Out("follows")
+)
+
 func testSet(qs graph.QuadStore) []test {
 	return []test{
 		{
@@ -197,9 +203,30 @@ func testSet(qs graph.QuadStore) []test {
 		},
 		{
 			message: "do multiple .Back()s",
-			path:    StartPath(qs, "emily").Out("follows").As("f").Out("follows").Out("status").Is("cool_person").Back("f").In("follows").In("follows").As("acd").Out("status").Is("cool_person").Back("f"),
+			path:    StartPath(qs, "emily").Out("follows").Tag("f").Out("follows").Out("status").Is("cool_person").Back("f").In("follows").In("follows").Tag("acd").Out("status").Is("cool_person").Back("f"),
 			tag:     "acd",
 			expect:  []string{"dani"},
+		},
+		{
+			message: "InPredicates()",
+			path:    StartPath(qs, "bob").InPredicates(),
+			expect:  []string{"follows"},
+		},
+		{
+			message: "OutPredicates()",
+			path:    StartPath(qs, "bob").OutPredicates(),
+			expect:  []string{"follows", "status"},
+		},
+		// Morphism tests
+		{
+			message: "show simple morphism",
+			path:    StartPath(qs, "charlie").Follow(grandfollows),
+			expect:  []string{"greg", "fred", "bob"},
+		},
+		{
+			message: "show reverse morphism",
+			path:    StartPath(qs, "fred").FollowReverse(grandfollows),
+			expect:  []string{"alice", "charlie", "dani"},
 		},
 	}
 }

--- a/query/gremlin/gremlin_test.go
+++ b/query/gremlin/gremlin_test.go
@@ -262,14 +262,14 @@ var testQueries = []struct {
 		query: `
 		  g.V().InPredicates().All()
 		`,
-		expect: []string{"follows", "status"},
+		expect: []string{"are", "follows", "status"},
 	},
 	{
 		message: "list all out predicates",
 		query: `
 		  g.V().OutPredicates().All()
 		`,
-		expect: []string{"follows", "status"},
+		expect: []string{"are", "follows", "status"},
 	},
 }
 

--- a/query/gremlin/gremlin_test.go
+++ b/query/gremlin/gremlin_test.go
@@ -322,6 +322,7 @@ func TestGremlin(t *testing.T) {
 		got := runQueryGetTag(simpleGraph, test.query, test.tag)
 		sort.Strings(got)
 		sort.Strings(test.expect)
+		t.Log("testing", test.message)
 		if !reflect.DeepEqual(got, test.expect) {
 			t.Errorf("Failed to %s, got: %v expected: %v", test.message, got, test.expect)
 		}

--- a/query/gremlin/traversals.go
+++ b/query/gremlin/traversals.go
@@ -21,27 +21,33 @@ import (
 	"github.com/robertkrimen/otto"
 )
 
+var traversals = []string{
+	"In",
+	"Out",
+	"Is",
+	"Both",
+	"Follow",
+	"FollowR",
+	"And",
+	"Intersect",
+	"Union",
+	"Or",
+	"Back",
+	"Tag",
+	"As",
+	"Has",
+	"Save",
+	"SaveR",
+	"Except",
+	"Difference",
+	"InPredicates",
+	"OutPredicates",
+}
+
 func (wk *worker) embedTraversals(env *otto.Otto, obj *otto.Object) {
-	obj.Set("In", wk.gremlinFunc("in", obj, env))
-	obj.Set("Out", wk.gremlinFunc("out", obj, env))
-	obj.Set("Is", wk.gremlinFunc("is", obj, env))
-	obj.Set("Both", wk.gremlinFunc("both", obj, env))
-	obj.Set("Follow", wk.gremlinFunc("follow", obj, env))
-	obj.Set("FollowR", wk.gremlinFollowR("followr", obj, env))
-	obj.Set("And", wk.gremlinFunc("and", obj, env))
-	obj.Set("Intersect", wk.gremlinFunc("and", obj, env))
-	obj.Set("Union", wk.gremlinFunc("or", obj, env))
-	obj.Set("Or", wk.gremlinFunc("or", obj, env))
-	obj.Set("Back", wk.gremlinBack("back", obj, env))
-	obj.Set("Tag", wk.gremlinFunc("tag", obj, env))
-	obj.Set("As", wk.gremlinFunc("tag", obj, env))
-	obj.Set("Has", wk.gremlinFunc("has", obj, env))
-	obj.Set("Save", wk.gremlinFunc("save", obj, env))
-	obj.Set("SaveR", wk.gremlinFunc("saver", obj, env))
-	obj.Set("Except", wk.gremlinFunc("except", obj, env))
-	obj.Set("Difference", wk.gremlinFunc("except", obj, env))
-	obj.Set("InPredicates", wk.gremlinFunc("in_predicates", obj, env))
-	obj.Set("OutPredicates", wk.gremlinFunc("out_predicates", obj, env))
+	for _, t := range traversals {
+		obj.Set(t, wk.gremlinFunc(t, obj, env))
+	}
 }
 
 func (wk *worker) gremlinFunc(kind string, prev *otto.Object, env *otto.Otto) func(otto.FunctionCall) otto.Value {
@@ -61,117 +67,6 @@ func (wk *worker) gremlinFunc(kind string, prev *otto.Object, env *otto.Otto) fu
 		}
 		return out.Value()
 	}
-}
-
-func (wk *worker) gremlinBack(kind string, prev *otto.Object, env *otto.Otto) func(otto.FunctionCall) otto.Value {
-	return func(call otto.FunctionCall) otto.Value {
-		call.Otto.Run("var out = {}")
-		out, _ := call.Otto.Object("out")
-		out.Set("_gremlin_type", kind)
-		out.Set("_gremlin_values", call.ArgumentList)
-		args := argsOf(call)
-		if len(args) > 0 {
-			out.Set("string_args", args)
-		}
-		var otherChain *otto.Object
-		var thisObj *otto.Object
-		if len(args) != 0 {
-			otherChain, thisObj = reverseGremlinChainTo(call.Otto, prev, args[0])
-		} else {
-			otherChain, thisObj = reverseGremlinChainTo(call.Otto, prev, "")
-		}
-		out.Set("_gremlin_prev", thisObj)
-		out.Set("_gremlin_back_chain", otherChain)
-		wk.embedTraversals(env, out)
-		if isVertexChain(call.This.Object()) {
-			wk.embedFinals(env, out)
-		}
-		return out.Value()
-	}
-}
-
-func (wk *worker) gremlinFollowR(kind string, prev *otto.Object, env *otto.Otto) func(otto.FunctionCall) otto.Value {
-	return func(call otto.FunctionCall) otto.Value {
-		call.Otto.Run("var out = {}")
-		out, _ := call.Otto.Object("out")
-		out.Set("_gremlin_type", kind)
-		out.Set("_gremlin_values", call.ArgumentList)
-		args := argsOf(call)
-		if len(args) > 0 {
-			out.Set("string_args", args)
-		}
-		if len(call.ArgumentList) == 0 {
-			return prev.Value()
-		}
-		arg := call.Argument(0)
-		if isVertexChain(arg.Object()) {
-			return prev.Value()
-		}
-		newChain, _ := reverseGremlinChainTo(call.Otto, arg.Object(), "")
-		out.Set("_gremlin_prev", prev)
-		out.Set("_gremlin_followr", newChain)
-		wk.embedTraversals(env, out)
-		if isVertexChain(call.This.Object()) {
-			wk.embedFinals(env, out)
-		}
-		return out.Value()
-	}
-}
-
-func reverseGremlinChainTo(env *otto.Otto, prev *otto.Object, tag string) (*otto.Object, *otto.Object) {
-	env.Run("var _base_object = {}")
-	base, err := env.Object("_base_object")
-	if err != nil {
-		glog.Error(err)
-		return otto.NullValue().Object(), otto.NullValue().Object()
-	}
-	if isVertexChain(prev) {
-		base.Set("_gremlin_type", "vertex")
-	} else {
-		base.Set("_gremlin_type", "morphism")
-	}
-	return reverseGremlinChainHelper(env, prev, base, tag)
-}
-
-func reverseGremlinChainHelper(env *otto.Otto, chain *otto.Object, newBase *otto.Object, tag string) (*otto.Object, *otto.Object) {
-	kindVal, _ := chain.Get("_gremlin_type")
-	kind := kindVal.String()
-
-	if tag != "" {
-		if kind == "tag" {
-			tags := propertiesOf(chain, "string_args")
-			for _, t := range tags {
-				if t == tag {
-					return newBase, chain
-				}
-			}
-		}
-	}
-
-	if kind == "morphism" || kind == "vertex" {
-		return newBase, chain
-	}
-	var newKind string
-	switch kind {
-	case "in":
-		newKind = "out"
-	case "out":
-		newKind = "in"
-	default:
-		newKind = kind
-	}
-	prev, _ := chain.Get("_gremlin_prev")
-	env.Run("var out = {}")
-	out, _ := env.Object("out")
-	out.Set("_gremlin_type", newKind)
-	values, _ := chain.Get("_gremlin_values")
-	out.Set("_gremlin_values", values)
-	back, _ := chain.Get("_gremlin_back_chain")
-	out.Set("_gremlin_back_chain", back)
-	out.Set("_gremlin_prev", newBase)
-	strings, _ := chain.Get("string_args")
-	out.Set("string_args", strings)
-	return reverseGremlinChainHelper(env, prev.Object(), out, tag)
 }
 
 func debugChain(obj *otto.Object) bool {


### PR DESCRIPTION
We were building iterators the same way in two places; the gremlin-esque path library and the Gremlin JS library. The latter now depends on the former.

This means two really great things: 1) the path library now has feature parity with the JS (yay) and 2) new features only need a single implementation in Go, and can easily be exposed in javascript.

The new context being routed through path.Path is in pursuit of a future feature; I started trying to do that and got diverted into doing a refactor.