### PR TITLE
add Triple function

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -27,6 +27,10 @@ type Handle struct {
 	graph.QuadWriter
 }
 
+func Triple(subject, predicate, object string) quad.Quad {
+	return quad.Quad{subject, predicate, object, ""}
+}
+
 func Quad(subject, predicate, object, label string) quad.Quad {
 	return quad.Quad{subject, predicate, object, label}
 }


### PR DESCRIPTION
This is a shortcut for those that are not using the label field. It can
become very verbose always calling Quad with an empty string as the last
parameter.

I've signed the CLA.