### PR TITLE
Fix NPE in SQL initialization

### DIFF
--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -64,10 +64,10 @@ func connectSQLTables(addr string, _ graph.Options) (*sql.DB, error) {
 
 func createSQLTables(addr string, options graph.Options) error {
 	conn, err := connectSQLTables(addr, options)
-	defer conn.Close()
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	tx, err := conn.Begin()
 	if err != nil {
 		glog.Errorf("Couldn't begin creation transaction: %s", err)


### PR DESCRIPTION
Happens when the database could not be opened. Introduced by e849da9.

Example:
```
E1206 19:31:25.879755 06891 quadstore.go:59] Couldn't open database at host=127.0.0.1 sslmode=disable: &pq.Error{Severity:"FATAL", Code:"3D000", Message:"database \"user\" does not exist", Detail:"", Hint:"", Position:"", InternalPosition:"", InternalQuery:"", Where:"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"postinit.c", Line:"794", Routine:"InitPostgres"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x42b8fa]

1: running
    sql      sql.go:504        (*DB).Close(0, 0, 0)
    sql      quadstore.go:69   createSQLTables(#3, 0x1e, #1, 0x1960000, 0xc82010a000)
    graph    quadstore.go:185  InitQuadStore(#2, 0x3, #3, 0x1e, #1, 0, 0)
    database database.go:91    Open(#2, 0x3, #3, 0x1e, 0, 0)
    main     main.go:104       main()
1: chan receive [Created by glog.init.1 @ glog.go:408]
    glog     glog.go:923       (*loggingT).flushDaemon(0xb0ac40)
1: chan receive [Created by sql.Open @ sql.go:481]
    sql      sql.go:634        (*DB).connectionOpener(#4)
1: syscall [Created by signal.init.1 @ signal_unix.go:28]
    signal   signal_unix.go:22 loop()
1: syscall [locked]
    runtime  asm_amd64.s:1696  goexit()
```